### PR TITLE
Add support for currency aliases

### DIFF
--- a/cleanse/cleanse.go
+++ b/cleanse/cleanse.go
@@ -43,9 +43,10 @@ type Country struct {
 }
 
 type Currency struct {
-	Name           string `json:"name"`
-	Iso_4217_3     string `json:"iso_4217_3"`
-	NumberDecimals int    `json:"number_decimals"`
+	Name              string `json:"name"`
+	Iso_4217_3        string `json:"iso_4217_3"`
+	Former_Iso_4217_3 []string `json:"former_iso_4217_3,omitempty"`
+	NumberDecimals    int    `json:"number_decimals"`
 }
 
 type CurrencyLocale struct {
@@ -101,9 +102,10 @@ type IncomingLanguageLocale struct {
 }
 
 type IncomingCurrency struct {
-	Name           string `json:"name"`
-	Iso_4217_3     string `json:"iso_4217_3"`
-	NumberDecimals int    `json:"number_decimals"`
+	Name              string `json:"name"`
+	Iso_4217_3        string `json:"iso_4217_3"`
+	NumberDecimals    int    `json:"number_decimals"`
+	Former_Iso_4217_3 []string `json:"former_iso_4217_3,omitempty"`
 }
 
 type IncomingNumbers struct {
@@ -555,6 +557,7 @@ func readCurrencies(file string) []Currency {
 			currencies = append(currencies, Currency{
 				Name:           c.Name,
 				Iso_4217_3:     c.Iso_4217_3,
+				Former_Iso_4217_3: c.Former_Iso_4217_3,
 				NumberDecimals: c.NumberDecimals,
 			})
 		}

--- a/common/common.go
+++ b/common/common.go
@@ -31,11 +31,12 @@ type Country struct {
 }
 
 type Currency struct {
-	Name           string           `json:"name"`
-	Iso_4217_3     string           `json:"iso_4217_3"`
-	NumberDecimals int              `json:"number_decimals"`
-	Symbols        *CurrencySymbols `json:"symbols,omitempty"`
-	DefaultLocale  string           `json:"default_locale,omitempty"`
+	Name              string           `json:"name"`
+	Iso_4217_3        string           `json:"iso_4217_3"`
+	NumberDecimals    int              `json:"number_decimals"`
+	Symbols           *CurrencySymbols `json:"symbols,omitempty"`
+	DefaultLocale     string           `json:"default_locale,omitempty"`
+	Former_Iso_4217_3 []string         `json:"former_iso_4217_3,omitempty"`
 }
 
 type CurrencySymbols struct {

--- a/data/cleansed/currencies.json
+++ b/data/cleansed/currencies.json
@@ -37,6 +37,9 @@
   {
     "name": "Azerbaijani manat",
     "iso_4217_3": "AZN",
+    "former_iso_4217_3": [
+      "AZM"
+    ],
     "number_decimals": 2
   },
   {

--- a/data/final/currencies.json
+++ b/data/final/currencies.json
@@ -48,7 +48,10 @@
     "name": "Azerbaijani manat",
     "iso_4217_3": "AZN",
     "number_decimals": 2,
-    "default_locale": "az"
+    "default_locale": "az",
+    "former_iso_4217_3": [
+      "AZM"
+    ]
   },
   {
     "name": "Bahamian Dollar",

--- a/data/original/currencies.json
+++ b/data/original/currencies.json
@@ -37,7 +37,8 @@
   {
     "iso_4217_3": "AZN",
     "name": "Azerbaijani manat",
-    "number_decimals": 2
+    "number_decimals": 2,
+    "former_iso_4217_3": ["AZM"]
   },
   {
     "iso_4217_3": "BAM",

--- a/final/final.go
+++ b/final/final.go
@@ -330,11 +330,12 @@ func commonCurrencies(data CleansedDataSet, locales []common.Locale) []common.Cu
 		}
 
 		all = append(all, common.Currency{
-			Name:           c.Name,
-			Iso_4217_3:     c.Iso_4217_3,
-			NumberDecimals: c.NumberDecimals,
-			Symbols:        commonSymbols,
-			DefaultLocale:  defaultLocale,
+			Name:              c.Name,
+			Iso_4217_3:        c.Iso_4217_3,
+			NumberDecimals:    c.NumberDecimals,
+			Symbols:           commonSymbols,
+			DefaultLocale:     defaultLocale,
+			Former_Iso_4217_3: c.Former_Iso_4217_3,
 		})
 	}
 	return all


### PR DESCRIPTION
- Azerbaijani manat is known by AZN (and formerly AZM)
 - Capture aliases in data so we can handle conversion automatically
 - The second manat was introduced on 15 August 1992.[1] It had the ISO 4217 code AZM and replaced the Soviet ruble at a rate of 10 rubles to 1 manat.
   From https://en.wikipedia.org/wiki/Azerbaijani_manat