### PR TITLE
Add deterministic sort for timezones by description then name

### DIFF
--- a/data/final/timezones.json
+++ b/data/final/timezones.json
@@ -130,12 +130,12 @@
     "offset": -720
   },
   {
-    "name": "America/Porto_Acre",
+    "name": "America/Eirunepe",
     "description": "Acre Time",
     "offset": -300
   },
   {
-    "name": "America/Eirunepe",
+    "name": "America/Porto_Acre",
     "description": "Acre Time",
     "offset": -300
   },
@@ -155,22 +155,7 @@
     "offset": 270
   },
   {
-    "name": "America/Nome",
-    "description": "Alaska Daylight Time",
-    "offset": -480
-  },
-  {
     "name": "America/Anchorage",
-    "description": "Alaska Daylight Time",
-    "offset": -480
-  },
-  {
-    "name": "America/Sitka",
-    "description": "Alaska Daylight Time",
-    "offset": -480
-  },
-  {
-    "name": "US/Alaska",
     "description": "Alaska Daylight Time",
     "offset": -480
   },
@@ -180,7 +165,22 @@
     "offset": -480
   },
   {
+    "name": "America/Nome",
+    "description": "Alaska Daylight Time",
+    "offset": -480
+  },
+  {
+    "name": "America/Sitka",
+    "description": "Alaska Daylight Time",
+    "offset": -480
+  },
+  {
     "name": "America/Yakutat",
+    "description": "Alaska Daylight Time",
+    "offset": -480
+  },
+  {
+    "name": "US/Alaska",
     "description": "Alaska Daylight Time",
     "offset": -480
   },
@@ -190,22 +190,7 @@
     "offset": 360
   },
   {
-    "name": "America/Manaus",
-    "description": "Amazon Time",
-    "offset": -240
-  },
-  {
     "name": "America/Boa_Vista",
-    "description": "Amazon Time",
-    "offset": -240
-  },
-  {
-    "name": "Brazil/West",
-    "description": "Amazon Time",
-    "offset": -240
-  },
-  {
-    "name": "America/Cuiaba",
     "description": "Amazon Time",
     "offset": -240
   },
@@ -215,7 +200,22 @@
     "offset": -240
   },
   {
+    "name": "America/Cuiaba",
+    "description": "Amazon Time",
+    "offset": -240
+  },
+  {
+    "name": "America/Manaus",
+    "description": "Amazon Time",
+    "offset": -240
+  },
+  {
     "name": "America/Porto_Velho",
+    "description": "Amazon Time",
+    "offset": -240
+  },
+  {
+    "name": "Brazil/West",
     "description": "Amazon Time",
     "offset": -240
   },
@@ -235,27 +235,7 @@
     "offset": 300
   },
   {
-    "name": "Asia/Riyadh",
-    "description": "Arabia Standard Time",
-    "offset": 180
-  },
-  {
-    "name": "Asia/Kuwait",
-    "description": "Arabia Standard Time",
-    "offset": 180
-  },
-  {
     "name": "Asia/Aden",
-    "description": "Arabia Standard Time",
-    "offset": 180
-  },
-  {
-    "name": "Asia/Qatar",
-    "description": "Arabia Standard Time",
-    "offset": 180
-  },
-  {
-    "name": "Asia/Bahrain",
     "description": "Arabia Standard Time",
     "offset": 180
   },
@@ -265,34 +245,24 @@
     "offset": 180
   },
   {
-    "name": "America/Jujuy",
-    "description": "Argentine Time",
-    "offset": -180
+    "name": "Asia/Bahrain",
+    "description": "Arabia Standard Time",
+    "offset": 180
   },
   {
-    "name": "America/Mendoza",
-    "description": "Argentine Time",
-    "offset": -180
+    "name": "Asia/Kuwait",
+    "description": "Arabia Standard Time",
+    "offset": 180
   },
   {
-    "name": "America/Buenos_Aires",
-    "description": "Argentine Time",
-    "offset": -180
+    "name": "Asia/Qatar",
+    "description": "Arabia Standard Time",
+    "offset": 180
   },
   {
-    "name": "America/Rosario",
-    "description": "Argentine Time",
-    "offset": -180
-  },
-  {
-    "name": "America/Cordoba",
-    "description": "Argentine Time",
-    "offset": -180
-  },
-  {
-    "name": "America/Argentina/Ushuaia",
-    "description": "Argentine Time",
-    "offset": -180
+    "name": "Asia/Riyadh",
+    "description": "Arabia Standard Time",
+    "offset": 180
   },
   {
     "name": "America/Argentina/Buenos_Aires",
@@ -355,7 +325,37 @@
     "offset": -180
   },
   {
+    "name": "America/Argentina/Ushuaia",
+    "description": "Argentine Time",
+    "offset": -180
+  },
+  {
+    "name": "America/Buenos_Aires",
+    "description": "Argentine Time",
+    "offset": -180
+  },
+  {
     "name": "America/Catamarca",
+    "description": "Argentine Time",
+    "offset": -180
+  },
+  {
+    "name": "America/Cordoba",
+    "description": "Argentine Time",
+    "offset": -180
+  },
+  {
+    "name": "America/Jujuy",
+    "description": "Argentine Time",
+    "offset": -180
+  },
+  {
+    "name": "America/Mendoza",
+    "description": "Argentine Time",
+    "offset": -180
+  },
+  {
+    "name": "America/Rosario",
     "description": "Argentine Time",
     "offset": -180
   },
@@ -365,17 +365,12 @@
     "offset": 240
   },
   {
-    "name": "Canada/Atlantic",
-    "description": "Atlantic Daylight Time",
-    "offset": -180
-  },
-  {
-    "name": "Atlantic/Bermuda",
-    "description": "Atlantic Daylight Time",
-    "offset": -180
-  },
-  {
     "name": "America/Glace_Bay",
+    "description": "Atlantic Daylight Time",
+    "offset": -180
+  },
+  {
+    "name": "America/Goose_Bay",
     "description": "Atlantic Daylight Time",
     "offset": -180
   },
@@ -390,12 +385,17 @@
     "offset": -180
   },
   {
-    "name": "America/Goose_Bay",
+    "name": "America/Thule",
     "description": "Atlantic Daylight Time",
     "offset": -180
   },
   {
-    "name": "America/Thule",
+    "name": "Atlantic/Bermuda",
+    "description": "Atlantic Daylight Time",
+    "offset": -180
+  },
+  {
+    "name": "Canada/Atlantic",
     "description": "Atlantic Daylight Time",
     "offset": -180
   },
@@ -405,32 +405,12 @@
     "offset": -240
   },
   {
-    "name": "America/Blanc-Sablon",
-    "description": "Atlantic Standard Time",
-    "offset": -240
-  },
-  {
-    "name": "America/Grenada",
-    "description": "Atlantic Standard Time",
-    "offset": -240
-  },
-  {
     "name": "America/Antigua",
     "description": "Atlantic Standard Time",
     "offset": -240
   },
   {
-    "name": "America/Montserrat",
-    "description": "Atlantic Standard Time",
-    "offset": -240
-  },
-  {
-    "name": "America/Grand_Turk",
-    "description": "Atlantic Standard Time",
-    "offset": -240
-  },
-  {
-    "name": "America/Port_of_Spain",
+    "name": "America/Aruba",
     "description": "Atlantic Standard Time",
     "offset": -240
   },
@@ -440,42 +420,12 @@
     "offset": -240
   },
   {
-    "name": "America/Puerto_Rico",
+    "name": "America/Blanc-Sablon",
     "description": "Atlantic Standard Time",
     "offset": -240
   },
   {
-    "name": "America/Kralendijk",
-    "description": "Atlantic Standard Time",
-    "offset": -240
-  },
-  {
-    "name": "America/Guadeloupe",
-    "description": "Atlantic Standard Time",
-    "offset": -240
-  },
-  {
-    "name": "America/Lower_Princes",
-    "description": "Atlantic Standard Time",
-    "offset": -240
-  },
-  {
-    "name": "America/Martinique",
-    "description": "Atlantic Standard Time",
-    "offset": -240
-  },
-  {
-    "name": "America/Santo_Domingo",
-    "description": "Atlantic Standard Time",
-    "offset": -240
-  },
-  {
-    "name": "America/Marigot",
-    "description": "Atlantic Standard Time",
-    "offset": -240
-  },
-  {
-    "name": "America/St_Barthelemy",
+    "name": "America/Curacao",
     "description": "Atlantic Standard Time",
     "offset": -240
   },
@@ -485,7 +435,62 @@
     "offset": -240
   },
   {
-    "name": "America/Virgin",
+    "name": "America/Grand_Turk",
+    "description": "Atlantic Standard Time",
+    "offset": -240
+  },
+  {
+    "name": "America/Grenada",
+    "description": "Atlantic Standard Time",
+    "offset": -240
+  },
+  {
+    "name": "America/Guadeloupe",
+    "description": "Atlantic Standard Time",
+    "offset": -240
+  },
+  {
+    "name": "America/Kralendijk",
+    "description": "Atlantic Standard Time",
+    "offset": -240
+  },
+  {
+    "name": "America/Lower_Princes",
+    "description": "Atlantic Standard Time",
+    "offset": -240
+  },
+  {
+    "name": "America/Marigot",
+    "description": "Atlantic Standard Time",
+    "offset": -240
+  },
+  {
+    "name": "America/Martinique",
+    "description": "Atlantic Standard Time",
+    "offset": -240
+  },
+  {
+    "name": "America/Montserrat",
+    "description": "Atlantic Standard Time",
+    "offset": -240
+  },
+  {
+    "name": "America/Port_of_Spain",
+    "description": "Atlantic Standard Time",
+    "offset": -240
+  },
+  {
+    "name": "America/Puerto_Rico",
+    "description": "Atlantic Standard Time",
+    "offset": -240
+  },
+  {
+    "name": "America/Santo_Domingo",
+    "description": "Atlantic Standard Time",
+    "offset": -240
+  },
+  {
+    "name": "America/St_Barthelemy",
     "description": "Atlantic Standard Time",
     "offset": -240
   },
@@ -495,12 +500,12 @@
     "offset": -240
   },
   {
-    "name": "America/St_Thomas",
+    "name": "America/St_Lucia",
     "description": "Atlantic Standard Time",
     "offset": -240
   },
   {
-    "name": "America/Curacao",
+    "name": "America/St_Thomas",
     "description": "Atlantic Standard Time",
     "offset": -240
   },
@@ -515,22 +520,17 @@
     "offset": -240
   },
   {
-    "name": "America/Aruba",
+    "name": "America/Virgin",
     "description": "Atlantic Standard Time",
     "offset": -240
   },
   {
-    "name": "America/St_Lucia",
-    "description": "Atlantic Standard Time",
-    "offset": -240
-  },
-  {
-    "name": "Australia/North",
+    "name": "Australia/Darwin",
     "description": "Australian Central Standard Time (Northern Territory)",
     "offset": 570
   },
   {
-    "name": "Australia/Darwin",
+    "name": "Australia/North",
     "description": "Australian Central Standard Time (Northern Territory)",
     "offset": 570
   },
@@ -560,17 +560,17 @@
     "offset": 525
   },
   {
-    "name": "Australia/Canberra",
-    "description": "Australian Eastern Standard Time (New South Wales)",
-    "offset": 600
-  },
-  {
     "name": "Australia/ACT",
     "description": "Australian Eastern Standard Time (New South Wales)",
     "offset": 600
   },
   {
-    "name": "Australia/Sydney",
+    "name": "Australia/Canberra",
+    "description": "Australian Eastern Standard Time (New South Wales)",
+    "offset": 600
+  },
+  {
+    "name": "Australia/Currie",
     "description": "Australian Eastern Standard Time (New South Wales)",
     "offset": 600
   },
@@ -580,7 +580,7 @@
     "offset": 600
   },
   {
-    "name": "Australia/Currie",
+    "name": "Australia/Sydney",
     "description": "Australian Eastern Standard Time (New South Wales)",
     "offset": 600
   },
@@ -620,7 +620,7 @@
     "offset": 600
   },
   {
-    "name": "Australia/West",
+    "name": "Antarctica/Casey",
     "description": "Australian Western Standard Time",
     "offset": 480
   },
@@ -630,7 +630,7 @@
     "offset": 480
   },
   {
-    "name": "Antarctica/Casey",
+    "name": "Australia/West",
     "description": "Australian Western Standard Time",
     "offset": 480
   },
@@ -675,17 +675,12 @@
     "offset": 660
   },
   {
-    "name": "America/Recife",
+    "name": "America/Araguaina",
     "description": "Brasilia Time",
     "offset": -180
   },
   {
-    "name": "America/Maceio",
-    "description": "Brasilia Time",
-    "offset": -180
-  },
-  {
-    "name": "America/Sao_Paulo",
+    "name": "America/Bahia",
     "description": "Brasilia Time",
     "offset": -180
   },
@@ -700,17 +695,12 @@
     "offset": -180
   },
   {
-    "name": "Brazil/East",
+    "name": "America/Maceio",
     "description": "Brasilia Time",
     "offset": -180
   },
   {
-    "name": "America/Araguaina",
-    "description": "Brasilia Time",
-    "offset": -180
-  },
-  {
-    "name": "America/Bahia",
+    "name": "America/Recife",
     "description": "Brasilia Time",
     "offset": -180
   },
@@ -720,12 +710,22 @@
     "offset": -180
   },
   {
-    "name": "GB",
+    "name": "America/Sao_Paulo",
+    "description": "Brasilia Time",
+    "offset": -180
+  },
+  {
+    "name": "Brazil/East",
+    "description": "Brasilia Time",
+    "offset": -180
+  },
+  {
+    "name": "Europe/Belfast",
     "description": "British Summer Time",
     "offset": 60
   },
   {
-    "name": "GB-Eire",
+    "name": "Europe/Guernsey",
     "description": "British Summer Time",
     "offset": 60
   },
@@ -740,17 +740,17 @@
     "offset": 60
   },
   {
-    "name": "Europe/Belfast",
-    "description": "British Summer Time",
-    "offset": 60
-  },
-  {
-    "name": "Europe/Guernsey",
-    "description": "British Summer Time",
-    "offset": 60
-  },
-  {
     "name": "Europe/London",
+    "description": "British Summer Time",
+    "offset": 60
+  },
+  {
+    "name": "GB",
+    "description": "British Summer Time",
+    "offset": 60
+  },
+  {
+    "name": "GB-Eire",
     "description": "British Summer Time",
     "offset": 60
   },
@@ -765,32 +765,7 @@
     "offset": -60
   },
   {
-    "name": "Africa/Lusaka",
-    "description": "Central African Time",
-    "offset": 120
-  },
-  {
-    "name": "Africa/Harare",
-    "description": "Central African Time",
-    "offset": 120
-  },
-  {
-    "name": "Africa/Maputo",
-    "description": "Central African Time",
-    "offset": 120
-  },
-  {
     "name": "Africa/Blantyre",
-    "description": "Central African Time",
-    "offset": 120
-  },
-  {
-    "name": "Africa/Kigali",
-    "description": "Central African Time",
-    "offset": 120
-  },
-  {
-    "name": "Africa/Lubumbashi",
     "description": "Central African Time",
     "offset": 120
   },
@@ -805,17 +780,32 @@
     "offset": 120
   },
   {
-    "name": "America/North_Dakota/Beulah",
-    "description": "Central Daylight Time",
-    "offset": -300
+    "name": "Africa/Harare",
+    "description": "Central African Time",
+    "offset": 120
   },
   {
-    "name": "America/Monterrey",
-    "description": "Central Daylight Time",
-    "offset": -300
+    "name": "Africa/Kigali",
+    "description": "Central African Time",
+    "offset": 120
   },
   {
-    "name": "US/Central",
+    "name": "Africa/Lubumbashi",
+    "description": "Central African Time",
+    "offset": 120
+  },
+  {
+    "name": "Africa/Lusaka",
+    "description": "Central African Time",
+    "offset": 120
+  },
+  {
+    "name": "Africa/Maputo",
+    "description": "Central African Time",
+    "offset": 120
+  },
+  {
+    "name": "America/Bahia_Banderas",
     "description": "Central Daylight Time",
     "offset": -300
   },
@@ -825,17 +815,7 @@
     "offset": -300
   },
   {
-    "name": "Mexico/General",
-    "description": "Central Daylight Time",
-    "offset": -300
-  },
-  {
-    "name": "CST6CDT",
-    "description": "Central Daylight Time",
-    "offset": -300
-  },
-  {
-    "name": "America/Resolute",
+    "name": "America/Indiana/Knox",
     "description": "Central Daylight Time",
     "offset": -300
   },
@@ -845,52 +825,7 @@
     "offset": -300
   },
   {
-    "name": "America/Indiana/Knox",
-    "description": "Central Daylight Time",
-    "offset": -300
-  },
-  {
-    "name": "America/Menominee",
-    "description": "Central Daylight Time",
-    "offset": -300
-  },
-  {
-    "name": "Canada/Central",
-    "description": "Central Daylight Time",
-    "offset": -300
-  },
-  {
-    "name": "America/North_Dakota/Center",
-    "description": "Central Daylight Time",
-    "offset": -300
-  },
-  {
-    "name": "America/North_Dakota/New_Salem",
-    "description": "Central Daylight Time",
-    "offset": -300
-  },
-  {
-    "name": "America/Rankin_Inlet",
-    "description": "Central Daylight Time",
-    "offset": -300
-  },
-  {
-    "name": "US/Indiana-Starke",
-    "description": "Central Daylight Time",
-    "offset": -300
-  },
-  {
-    "name": "America/Winnipeg",
-    "description": "Central Daylight Time",
-    "offset": -300
-  },
-  {
-    "name": "America/Rainy_River",
-    "description": "Central Daylight Time",
-    "offset": -300
-  },
-  {
-    "name": "America/Bahia_Banderas",
+    "name": "America/Knox_IN",
     "description": "Central Daylight Time",
     "offset": -300
   },
@@ -900,7 +835,7 @@
     "offset": -300
   },
   {
-    "name": "America/Knox_IN",
+    "name": "America/Menominee",
     "description": "Central Daylight Time",
     "offset": -300
   },
@@ -915,32 +850,87 @@
     "offset": -300
   },
   {
-    "name": "Europe/San_Marino",
+    "name": "America/Monterrey",
+    "description": "Central Daylight Time",
+    "offset": -300
+  },
+  {
+    "name": "America/North_Dakota/Beulah",
+    "description": "Central Daylight Time",
+    "offset": -300
+  },
+  {
+    "name": "America/North_Dakota/Center",
+    "description": "Central Daylight Time",
+    "offset": -300
+  },
+  {
+    "name": "America/North_Dakota/New_Salem",
+    "description": "Central Daylight Time",
+    "offset": -300
+  },
+  {
+    "name": "America/Rainy_River",
+    "description": "Central Daylight Time",
+    "offset": -300
+  },
+  {
+    "name": "America/Rankin_Inlet",
+    "description": "Central Daylight Time",
+    "offset": -300
+  },
+  {
+    "name": "America/Resolute",
+    "description": "Central Daylight Time",
+    "offset": -300
+  },
+  {
+    "name": "America/Winnipeg",
+    "description": "Central Daylight Time",
+    "offset": -300
+  },
+  {
+    "name": "Canada/Central",
+    "description": "Central Daylight Time",
+    "offset": -300
+  },
+  {
+    "name": "CST6CDT",
+    "description": "Central Daylight Time",
+    "offset": -300
+  },
+  {
+    "name": "Mexico/General",
+    "description": "Central Daylight Time",
+    "offset": -300
+  },
+  {
+    "name": "US/Central",
+    "description": "Central Daylight Time",
+    "offset": -300
+  },
+  {
+    "name": "US/Indiana-Starke",
+    "description": "Central Daylight Time",
+    "offset": -300
+  },
+  {
+    "name": "Africa/Ceuta",
     "description": "Central European Summer Time",
     "offset": 120
   },
   {
-    "name": "Europe/Ljubljana",
+    "name": "Antarctica/Troll",
     "description": "Central European Summer Time",
     "offset": 120
   },
   {
-    "name": "Europe/Luxembourg",
+    "name": "Arctic/Longyearbyen",
     "description": "Central European Summer Time",
     "offset": 120
   },
   {
-    "name": "Europe/Malta",
-    "description": "Central European Summer Time",
-    "offset": 120
-  },
-  {
-    "name": "Europe/Andorra",
-    "description": "Central European Summer Time",
-    "offset": 120
-  },
-  {
-    "name": "Europe/Monaco",
+    "name": "Atlantic/Jan_Mayen",
     "description": "Central European Summer Time",
     "offset": 120
   },
@@ -955,7 +945,72 @@
     "offset": 120
   },
   {
-    "name": "Europe/Zurich",
+    "name": "Europe/Andorra",
+    "description": "Central European Summer Time",
+    "offset": 120
+  },
+  {
+    "name": "Europe/Belgrade",
+    "description": "Central European Summer Time",
+    "offset": 120
+  },
+  {
+    "name": "Europe/Berlin",
+    "description": "Central European Summer Time",
+    "offset": 120
+  },
+  {
+    "name": "Europe/Bratislava",
+    "description": "Central European Summer Time",
+    "offset": 120
+  },
+  {
+    "name": "Europe/Brussels",
+    "description": "Central European Summer Time",
+    "offset": 120
+  },
+  {
+    "name": "Europe/Budapest",
+    "description": "Central European Summer Time",
+    "offset": 120
+  },
+  {
+    "name": "Europe/Busingen",
+    "description": "Central European Summer Time",
+    "offset": 120
+  },
+  {
+    "name": "Europe/Copenhagen",
+    "description": "Central European Summer Time",
+    "offset": 120
+  },
+  {
+    "name": "Europe/Gibraltar",
+    "description": "Central European Summer Time",
+    "offset": 120
+  },
+  {
+    "name": "Europe/Ljubljana",
+    "description": "Central European Summer Time",
+    "offset": 120
+  },
+  {
+    "name": "Europe/Luxembourg",
+    "description": "Central European Summer Time",
+    "offset": 120
+  },
+  {
+    "name": "Europe/Madrid",
+    "description": "Central European Summer Time",
+    "offset": 120
+  },
+  {
+    "name": "Europe/Malta",
+    "description": "Central European Summer Time",
+    "offset": 120
+  },
+  {
+    "name": "Europe/Monaco",
     "description": "Central European Summer Time",
     "offset": 120
   },
@@ -970,27 +1025,7 @@
     "offset": 120
   },
   {
-    "name": "Poland",
-    "description": "Central European Summer Time",
-    "offset": 120
-  },
-  {
-    "name": "Europe/Zagreb",
-    "description": "Central European Summer Time",
-    "offset": 120
-  },
-  {
-    "name": "Arctic/Longyearbyen",
-    "description": "Central European Summer Time",
-    "offset": 120
-  },
-  {
     "name": "Europe/Podgorica",
-    "description": "Central European Summer Time",
-    "offset": 120
-  },
-  {
-    "name": "Europe/Warsaw",
     "description": "Central European Summer Time",
     "offset": 120
   },
@@ -1000,77 +1035,12 @@
     "offset": 120
   },
   {
-    "name": "Europe/Belgrade",
+    "name": "Europe/Rome",
     "description": "Central European Summer Time",
     "offset": 120
   },
   {
-    "name": "Africa/Ceuta",
-    "description": "Central European Summer Time",
-    "offset": 120
-  },
-  {
-    "name": "Europe/Vienna",
-    "description": "Central European Summer Time",
-    "offset": 120
-  },
-  {
-    "name": "Atlantic/Jan_Mayen",
-    "description": "Central European Summer Time",
-    "offset": 120
-  },
-  {
-    "name": "Europe/Vatican",
-    "description": "Central European Summer Time",
-    "offset": 120
-  },
-  {
-    "name": "Antarctica/Troll",
-    "description": "Central European Summer Time",
-    "offset": 120
-  },
-  {
-    "name": "Europe/Vaduz",
-    "description": "Central European Summer Time",
-    "offset": 120
-  },
-  {
-    "name": "Europe/Madrid",
-    "description": "Central European Summer Time",
-    "offset": 120
-  },
-  {
-    "name": "Europe/Bratislava",
-    "description": "Central European Summer Time",
-    "offset": 120
-  },
-  {
-    "name": "Europe/Tirane",
-    "description": "Central European Summer Time",
-    "offset": 120
-  },
-  {
-    "name": "Europe/Brussels",
-    "description": "Central European Summer Time",
-    "offset": 120
-  },
-  {
-    "name": "Europe/Stockholm",
-    "description": "Central European Summer Time",
-    "offset": 120
-  },
-  {
-    "name": "Europe/Budapest",
-    "description": "Central European Summer Time",
-    "offset": 120
-  },
-  {
-    "name": "Europe/Skopje",
-    "description": "Central European Summer Time",
-    "offset": 120
-  },
-  {
-    "name": "Europe/Copenhagen",
+    "name": "Europe/San_Marino",
     "description": "Central European Summer Time",
     "offset": 120
   },
@@ -1080,32 +1050,62 @@
     "offset": 120
   },
   {
-    "name": "Europe/Rome",
+    "name": "Europe/Skopje",
     "description": "Central European Summer Time",
     "offset": 120
   },
   {
-    "name": "Europe/Busingen",
+    "name": "Europe/Stockholm",
     "description": "Central European Summer Time",
     "offset": 120
   },
   {
-    "name": "Europe/Berlin",
+    "name": "Europe/Tirane",
     "description": "Central European Summer Time",
     "offset": 120
   },
   {
-    "name": "Europe/Gibraltar",
+    "name": "Europe/Vaduz",
     "description": "Central European Summer Time",
     "offset": 120
   },
   {
-    "name": "Africa/Tunis",
+    "name": "Europe/Vatican",
+    "description": "Central European Summer Time",
+    "offset": 120
+  },
+  {
+    "name": "Europe/Vienna",
+    "description": "Central European Summer Time",
+    "offset": 120
+  },
+  {
+    "name": "Europe/Warsaw",
+    "description": "Central European Summer Time",
+    "offset": 120
+  },
+  {
+    "name": "Europe/Zagreb",
+    "description": "Central European Summer Time",
+    "offset": 120
+  },
+  {
+    "name": "Europe/Zurich",
+    "description": "Central European Summer Time",
+    "offset": 120
+  },
+  {
+    "name": "Poland",
+    "description": "Central European Summer Time",
+    "offset": 120
+  },
+  {
+    "name": "Africa/Algiers",
     "description": "Central European Time",
     "offset": 60
   },
   {
-    "name": "Africa/Algiers",
+    "name": "Africa/Tunis",
     "description": "Central European Time",
     "offset": 60
   },
@@ -1120,22 +1120,7 @@
     "offset": 480
   },
   {
-    "name": "America/Swift_Current",
-    "description": "Central Standard Time",
-    "offset": -360
-  },
-  {
-    "name": "America/Guatemala",
-    "description": "Central Standard Time",
-    "offset": -360
-  },
-  {
-    "name": "America/Regina",
-    "description": "Central Standard Time",
-    "offset": -360
-  },
-  {
-    "name": "America/Tegucigalpa",
+    "name": "America/Belize",
     "description": "Central Standard Time",
     "offset": -360
   },
@@ -1145,12 +1130,12 @@
     "offset": -360
   },
   {
-    "name": "America/Belize",
+    "name": "America/El_Salvador",
     "description": "Central Standard Time",
     "offset": -360
   },
   {
-    "name": "America/El_Salvador",
+    "name": "America/Guatemala",
     "description": "Central Standard Time",
     "offset": -360
   },
@@ -1160,7 +1145,17 @@
     "offset": -360
   },
   {
-    "name": "Canada/Saskatchewan",
+    "name": "America/Regina",
+    "description": "Central Standard Time",
+    "offset": -360
+  },
+  {
+    "name": "America/Swift_Current",
+    "description": "Central Standard Time",
+    "offset": -360
+  },
+  {
+    "name": "America/Tegucigalpa",
     "description": "Central Standard Time",
     "offset": -360
   },
@@ -1170,9 +1165,9 @@
     "offset": -360
   },
   {
-    "name": "Pacific/Saipan",
-    "description": "Chamorro Standard Time",
-    "offset": 600
+    "name": "Canada/Saskatchewan",
+    "description": "Central Standard Time",
+    "offset": -360
   },
   {
     "name": "Pacific/Guam",
@@ -1180,14 +1175,24 @@
     "offset": 600
   },
   {
-    "name": "Pacific/Chatham",
-    "description": "Chatham Standard Time",
-    "offset": 765
+    "name": "Pacific/Saipan",
+    "description": "Chamorro Standard Time",
+    "offset": 600
   },
   {
     "name": "NZ-CHAT",
     "description": "Chatham Standard Time",
     "offset": 765
+  },
+  {
+    "name": "Pacific/Chatham",
+    "description": "Chatham Standard Time",
+    "offset": 765
+  },
+  {
+    "name": "America/Santiago",
+    "description": "Chile Time",
+    "offset": -180
   },
   {
     "name": "Antarctica/Palmer",
@@ -1200,37 +1205,7 @@
     "offset": -180
   },
   {
-    "name": "America/Santiago",
-    "description": "Chile Time",
-    "offset": -180
-  },
-  {
-    "name": "Asia/Macau",
-    "description": "China Standard Time",
-    "offset": 480
-  },
-  {
-    "name": "Asia/Taipei",
-    "description": "China Standard Time",
-    "offset": 480
-  },
-  {
-    "name": "Asia/Macao",
-    "description": "China Standard Time",
-    "offset": 480
-  },
-  {
-    "name": "ROC",
-    "description": "China Standard Time",
-    "offset": 480
-  },
-  {
-    "name": "PRC",
-    "description": "China Standard Time",
-    "offset": 480
-  },
-  {
-    "name": "Asia/Harbin",
+    "name": "Asia/Chongqing",
     "description": "China Standard Time",
     "offset": 480
   },
@@ -1240,12 +1215,37 @@
     "offset": 480
   },
   {
+    "name": "Asia/Harbin",
+    "description": "China Standard Time",
+    "offset": 480
+  },
+  {
+    "name": "Asia/Macao",
+    "description": "China Standard Time",
+    "offset": 480
+  },
+  {
+    "name": "Asia/Macau",
+    "description": "China Standard Time",
+    "offset": 480
+  },
+  {
     "name": "Asia/Shanghai",
     "description": "China Standard Time",
     "offset": 480
   },
   {
-    "name": "Asia/Chongqing",
+    "name": "Asia/Taipei",
+    "description": "China Standard Time",
+    "offset": 480
+  },
+  {
+    "name": "PRC",
+    "description": "China Standard Time",
+    "offset": 480
+  },
+  {
+    "name": "ROC",
     "description": "China Standard Time",
     "offset": 480
   },
@@ -1260,7 +1260,7 @@
     "offset": 420
   },
   {
-    "name": "Pacific/Yap",
+    "name": "Pacific/Chuuk",
     "description": "Chuuk Time",
     "offset": 600
   },
@@ -1270,7 +1270,7 @@
     "offset": 600
   },
   {
-    "name": "Pacific/Chuuk",
+    "name": "Pacific/Yap",
     "description": "Chuuk Time",
     "offset": 600
   },
@@ -1290,12 +1290,7 @@
     "offset": -600
   },
   {
-    "name": "UTC",
-    "description": "Coordinated Universal Time",
-    "offset": 0
-  },
-  {
-    "name": "Universal",
+    "name": "Etc/UCT",
     "description": "Coordinated Universal Time",
     "offset": 0
   },
@@ -1305,27 +1300,32 @@
     "offset": 0
   },
   {
-    "name": "UCT",
-    "description": "Coordinated Universal Time",
-    "offset": 0
-  },
-  {
-    "name": "Etc/UCT",
-    "description": "Coordinated Universal Time",
-    "offset": 0
-  },
-  {
     "name": "Etc/UTC",
     "description": "Coordinated Universal Time",
     "offset": 0
   },
   {
-    "name": "Zulu",
+    "name": "Etc/Zulu",
     "description": "Coordinated Universal Time",
     "offset": 0
   },
   {
-    "name": "Etc/Zulu",
+    "name": "UCT",
+    "description": "Coordinated Universal Time",
+    "offset": 0
+  },
+  {
+    "name": "Universal",
+    "description": "Coordinated Universal Time",
+    "offset": 0
+  },
+  {
+    "name": "UTC",
+    "description": "Coordinated Universal Time",
+    "offset": 0
+  },
+  {
+    "name": "Zulu",
     "description": "Coordinated Universal Time",
     "offset": 0
   },
@@ -1365,52 +1365,7 @@
     "offset": -300
   },
   {
-    "name": "Africa/Dar_es_Salaam",
-    "description": "Eastern African Time",
-    "offset": 180
-  },
-  {
-    "name": "Indian/Mayotte",
-    "description": "Eastern African Time",
-    "offset": 180
-  },
-  {
-    "name": "Africa/Khartoum",
-    "description": "Eastern African Time",
-    "offset": 180
-  },
-  {
-    "name": "Africa/Nairobi",
-    "description": "Eastern African Time",
-    "offset": 180
-  },
-  {
-    "name": "Africa/Kampala",
-    "description": "Eastern African Time",
-    "offset": 180
-  },
-  {
-    "name": "Africa/Asmera",
-    "description": "Eastern African Time",
-    "offset": 180
-  },
-  {
-    "name": "Indian/Comoro",
-    "description": "Eastern African Time",
-    "offset": 180
-  },
-  {
-    "name": "Africa/Juba",
-    "description": "Eastern African Time",
-    "offset": 180
-  },
-  {
     "name": "Africa/Addis_Ababa",
-    "description": "Eastern African Time",
-    "offset": 180
-  },
-  {
-    "name": "Africa/Mogadishu",
     "description": "Eastern African Time",
     "offset": 180
   },
@@ -1420,7 +1375,12 @@
     "offset": 180
   },
   {
-    "name": "Indian/Antananarivo",
+    "name": "Africa/Asmera",
+    "description": "Eastern African Time",
+    "offset": 180
+  },
+  {
+    "name": "Africa/Dar_es_Salaam",
     "description": "Eastern African Time",
     "offset": 180
   },
@@ -1430,99 +1390,44 @@
     "offset": 180
   },
   {
-    "name": "America/Kentucky/Louisville",
-    "description": "Eastern Daylight Time",
-    "offset": -240
+    "name": "Africa/Juba",
+    "description": "Eastern African Time",
+    "offset": 180
   },
   {
-    "name": "America/Toronto",
-    "description": "Eastern Daylight Time",
-    "offset": -240
+    "name": "Africa/Kampala",
+    "description": "Eastern African Time",
+    "offset": 180
   },
   {
-    "name": "America/Port-au-Prince",
-    "description": "Eastern Daylight Time",
-    "offset": -240
+    "name": "Africa/Khartoum",
+    "description": "Eastern African Time",
+    "offset": 180
   },
   {
-    "name": "America/Indianapolis",
-    "description": "Eastern Daylight Time",
-    "offset": -240
+    "name": "Africa/Mogadishu",
+    "description": "Eastern African Time",
+    "offset": 180
   },
   {
-    "name": "America/Iqaluit",
-    "description": "Eastern Daylight Time",
-    "offset": -240
+    "name": "Africa/Nairobi",
+    "description": "Eastern African Time",
+    "offset": 180
   },
   {
-    "name": "America/Indiana/Winamac",
-    "description": "Eastern Daylight Time",
-    "offset": -240
+    "name": "Indian/Antananarivo",
+    "description": "Eastern African Time",
+    "offset": 180
   },
   {
-    "name": "America/Kentucky/Monticello",
-    "description": "Eastern Daylight Time",
-    "offset": -240
+    "name": "Indian/Comoro",
+    "description": "Eastern African Time",
+    "offset": 180
   },
   {
-    "name": "America/Thunder_Bay",
-    "description": "Eastern Daylight Time",
-    "offset": -240
-  },
-  {
-    "name": "America/Indiana/Vincennes",
-    "description": "Eastern Daylight Time",
-    "offset": -240
-  },
-  {
-    "name": "America/Indiana/Vevay",
-    "description": "Eastern Daylight Time",
-    "offset": -240
-  },
-  {
-    "name": "EST5EDT",
-    "description": "Eastern Daylight Time",
-    "offset": -240
-  },
-  {
-    "name": "America/New_York",
-    "description": "Eastern Daylight Time",
-    "offset": -240
-  },
-  {
-    "name": "America/Indiana/Marengo",
-    "description": "Eastern Daylight Time",
-    "offset": -240
-  },
-  {
-    "name": "US/East-Indiana",
-    "description": "Eastern Daylight Time",
-    "offset": -240
-  },
-  {
-    "name": "US/Eastern",
-    "description": "Eastern Daylight Time",
-    "offset": -240
-  },
-  {
-    "name": "America/Louisville",
-    "description": "Eastern Daylight Time",
-    "offset": -240
-  },
-  {
-    "name": "America/Nassau",
-    "description": "Eastern Daylight Time",
-    "offset": -240
-  },
-  {
-    "name": "America/Detroit",
-    "description": "Eastern Daylight Time",
-    "offset": -240
-  },
-  {
-    "name": "Canada/Eastern",
-    "description": "Eastern Daylight Time",
-    "offset": -240
+    "name": "Indian/Mayotte",
+    "description": "Eastern African Time",
+    "offset": 180
   },
   {
     "name": "America/Cayman",
@@ -1530,22 +1435,7 @@
     "offset": -240
   },
   {
-    "name": "America/Pangnirtung",
-    "description": "Eastern Daylight Time",
-    "offset": -240
-  },
-  {
-    "name": "US/Michigan",
-    "description": "Eastern Daylight Time",
-    "offset": -240
-  },
-  {
-    "name": "America/Indiana/Petersburg",
-    "description": "Eastern Daylight Time",
-    "offset": -240
-  },
-  {
-    "name": "America/Montreal",
+    "name": "America/Detroit",
     "description": "Eastern Daylight Time",
     "offset": -240
   },
@@ -1560,12 +1450,157 @@
     "offset": -240
   },
   {
+    "name": "America/Indiana/Marengo",
+    "description": "Eastern Daylight Time",
+    "offset": -240
+  },
+  {
+    "name": "America/Indiana/Petersburg",
+    "description": "Eastern Daylight Time",
+    "offset": -240
+  },
+  {
+    "name": "America/Indiana/Vevay",
+    "description": "Eastern Daylight Time",
+    "offset": -240
+  },
+  {
+    "name": "America/Indiana/Vincennes",
+    "description": "Eastern Daylight Time",
+    "offset": -240
+  },
+  {
+    "name": "America/Indiana/Winamac",
+    "description": "Eastern Daylight Time",
+    "offset": -240
+  },
+  {
+    "name": "America/Indianapolis",
+    "description": "Eastern Daylight Time",
+    "offset": -240
+  },
+  {
+    "name": "America/Iqaluit",
+    "description": "Eastern Daylight Time",
+    "offset": -240
+  },
+  {
+    "name": "America/Kentucky/Louisville",
+    "description": "Eastern Daylight Time",
+    "offset": -240
+  },
+  {
+    "name": "America/Kentucky/Monticello",
+    "description": "Eastern Daylight Time",
+    "offset": -240
+  },
+  {
+    "name": "America/Louisville",
+    "description": "Eastern Daylight Time",
+    "offset": -240
+  },
+  {
+    "name": "America/Montreal",
+    "description": "Eastern Daylight Time",
+    "offset": -240
+  },
+  {
+    "name": "America/Nassau",
+    "description": "Eastern Daylight Time",
+    "offset": -240
+  },
+  {
+    "name": "America/New_York",
+    "description": "Eastern Daylight Time",
+    "offset": -240
+  },
+  {
     "name": "America/Nipigon",
     "description": "Eastern Daylight Time",
     "offset": -240
   },
   {
-    "name": "Europe/Uzhgorod",
+    "name": "America/Pangnirtung",
+    "description": "Eastern Daylight Time",
+    "offset": -240
+  },
+  {
+    "name": "America/Port-au-Prince",
+    "description": "Eastern Daylight Time",
+    "offset": -240
+  },
+  {
+    "name": "America/Thunder_Bay",
+    "description": "Eastern Daylight Time",
+    "offset": -240
+  },
+  {
+    "name": "America/Toronto",
+    "description": "Eastern Daylight Time",
+    "offset": -240
+  },
+  {
+    "name": "Canada/Eastern",
+    "description": "Eastern Daylight Time",
+    "offset": -240
+  },
+  {
+    "name": "EST5EDT",
+    "description": "Eastern Daylight Time",
+    "offset": -240
+  },
+  {
+    "name": "US/East-Indiana",
+    "description": "Eastern Daylight Time",
+    "offset": -240
+  },
+  {
+    "name": "US/Eastern",
+    "description": "Eastern Daylight Time",
+    "offset": -240
+  },
+  {
+    "name": "US/Michigan",
+    "description": "Eastern Daylight Time",
+    "offset": -240
+  },
+  {
+    "name": "Asia/Amman",
+    "description": "Eastern European Summer Time",
+    "offset": 180
+  },
+  {
+    "name": "Asia/Beirut",
+    "description": "Eastern European Summer Time",
+    "offset": 180
+  },
+  {
+    "name": "Asia/Damascus",
+    "description": "Eastern European Summer Time",
+    "offset": 180
+  },
+  {
+    "name": "Asia/Gaza",
+    "description": "Eastern European Summer Time",
+    "offset": 180
+  },
+  {
+    "name": "Asia/Hebron",
+    "description": "Eastern European Summer Time",
+    "offset": 180
+  },
+  {
+    "name": "Asia/Istanbul",
+    "description": "Eastern European Summer Time",
+    "offset": 180
+  },
+  {
+    "name": "Asia/Nicosia",
+    "description": "Eastern European Summer Time",
+    "offset": 180
+  },
+  {
+    "name": "EET",
     "description": "Eastern European Summer Time",
     "offset": 180
   },
@@ -1575,7 +1610,22 @@
     "offset": 180
   },
   {
-    "name": "Asia/Beirut",
+    "name": "Europe/Bucharest",
+    "description": "Eastern European Summer Time",
+    "offset": 180
+  },
+  {
+    "name": "Europe/Chisinau",
+    "description": "Eastern European Summer Time",
+    "offset": 180
+  },
+  {
+    "name": "Europe/Helsinki",
+    "description": "Eastern European Summer Time",
+    "offset": 180
+  },
+  {
+    "name": "Europe/Istanbul",
     "description": "Eastern European Summer Time",
     "offset": 180
   },
@@ -1590,92 +1640,7 @@
     "offset": 180
   },
   {
-    "name": "Europe/Bucharest",
-    "description": "Eastern European Summer Time",
-    "offset": 180
-  },
-  {
-    "name": "Asia/Amman",
-    "description": "Eastern European Summer Time",
-    "offset": 180
-  },
-  {
-    "name": "Europe/Istanbul",
-    "description": "Eastern European Summer Time",
-    "offset": 180
-  },
-  {
     "name": "Europe/Nicosia",
-    "description": "Eastern European Summer Time",
-    "offset": 180
-  },
-  {
-    "name": "Asia/Damascus",
-    "description": "Eastern European Summer Time",
-    "offset": 180
-  },
-  {
-    "name": "Asia/Istanbul",
-    "description": "Eastern European Summer Time",
-    "offset": 180
-  },
-  {
-    "name": "Europe/Helsinki",
-    "description": "Eastern European Summer Time",
-    "offset": 180
-  },
-  {
-    "name": "Europe/Chisinau",
-    "description": "Eastern European Summer Time",
-    "offset": 180
-  },
-  {
-    "name": "Asia/Gaza",
-    "description": "Eastern European Summer Time",
-    "offset": 180
-  },
-  {
-    "name": "Asia/Nicosia",
-    "description": "Eastern European Summer Time",
-    "offset": 180
-  },
-  {
-    "name": "Asia/Hebron",
-    "description": "Eastern European Summer Time",
-    "offset": 180
-  },
-  {
-    "name": "Europe/Zaporozhye",
-    "description": "Eastern European Summer Time",
-    "offset": 180
-  },
-  {
-    "name": "Europe/Vilnius",
-    "description": "Eastern European Summer Time",
-    "offset": 180
-  },
-  {
-    "name": "Europe/Tiraspol",
-    "description": "Eastern European Summer Time",
-    "offset": 180
-  },
-  {
-    "name": "Europe/Tallinn",
-    "description": "Eastern European Summer Time",
-    "offset": 180
-  },
-  {
-    "name": "Europe/Sofia",
-    "description": "Eastern European Summer Time",
-    "offset": 180
-  },
-  {
-    "name": "Turkey",
-    "description": "Eastern European Summer Time",
-    "offset": 180
-  },
-  {
-    "name": "EET",
     "description": "Eastern European Summer Time",
     "offset": 180
   },
@@ -1685,12 +1650,42 @@
     "offset": 180
   },
   {
-    "name": "Libya",
-    "description": "Eastern European Time",
-    "offset": 120
+    "name": "Europe/Sofia",
+    "description": "Eastern European Summer Time",
+    "offset": 180
   },
   {
-    "name": "Egypt",
+    "name": "Europe/Tallinn",
+    "description": "Eastern European Summer Time",
+    "offset": 180
+  },
+  {
+    "name": "Europe/Tiraspol",
+    "description": "Eastern European Summer Time",
+    "offset": 180
+  },
+  {
+    "name": "Europe/Uzhgorod",
+    "description": "Eastern European Summer Time",
+    "offset": 180
+  },
+  {
+    "name": "Europe/Vilnius",
+    "description": "Eastern European Summer Time",
+    "offset": 180
+  },
+  {
+    "name": "Europe/Zaporozhye",
+    "description": "Eastern European Summer Time",
+    "offset": 180
+  },
+  {
+    "name": "Turkey",
+    "description": "Eastern European Summer Time",
+    "offset": 180
+  },
+  {
+    "name": "Africa/Cairo",
     "description": "Eastern European Time",
     "offset": 120
   },
@@ -1700,7 +1695,7 @@
     "offset": 120
   },
   {
-    "name": "Africa/Cairo",
+    "name": "Egypt",
     "description": "Eastern European Time",
     "offset": 120
   },
@@ -1710,12 +1705,17 @@
     "offset": 120
   },
   {
+    "name": "Libya",
+    "description": "Eastern European Time",
+    "offset": 120
+  },
+  {
     "name": "America/Scoresbysund",
     "description": "Eastern Greenland Summer Time",
     "offset": 0
   },
   {
-    "name": "EST",
+    "name": "America/Atikokan",
     "description": "Eastern Standard Time",
     "offset": -300
   },
@@ -1725,17 +1725,12 @@
     "offset": -300
   },
   {
-    "name": "America/Atikokan",
-    "description": "Eastern Standard Time",
-    "offset": -300
-  },
-  {
-    "name": "Jamaica",
-    "description": "Eastern Standard Time",
-    "offset": -300
-  },
-  {
     "name": "America/Coral_Harbour",
+    "description": "Eastern Standard Time",
+    "offset": -300
+  },
+  {
+    "name": "America/Jamaica",
     "description": "Eastern Standard Time",
     "offset": -300
   },
@@ -1745,7 +1740,12 @@
     "offset": -300
   },
   {
-    "name": "America/Jamaica",
+    "name": "EST",
+    "description": "Eastern Standard Time",
+    "offset": -300
+  },
+  {
+    "name": "Jamaica",
     "description": "Eastern Standard Time",
     "offset": -300
   },
@@ -1760,12 +1760,12 @@
     "offset": -180
   },
   {
-    "name": "Brazil/DeNoronha",
+    "name": "America/Noronha",
     "description": "Fernando de Noronha Time",
     "offset": -120
   },
   {
-    "name": "America/Noronha",
+    "name": "Brazil/DeNoronha",
     "description": "Fernando de Noronha Time",
     "offset": -120
   },
@@ -1810,77 +1810,7 @@
     "offset": 720
   },
   {
-    "name": "Iceland",
-    "description": "Greenwich Mean Time",
-    "offset": 0
-  },
-  {
-    "name": "Africa/Freetown",
-    "description": "Greenwich Mean Time",
-    "offset": 0
-  },
-  {
-    "name": "Africa/Dakar",
-    "description": "Greenwich Mean Time",
-    "offset": 0
-  },
-  {
-    "name": "Etc/GMT0",
-    "description": "Greenwich Mean Time",
-    "offset": 0
-  },
-  {
-    "name": "Africa/Bissau",
-    "description": "Greenwich Mean Time",
-    "offset": 0
-  },
-  {
-    "name": "Etc/Greenwich",
-    "description": "Greenwich Mean Time",
-    "offset": 0
-  },
-  {
-    "name": "Africa/Monrovia",
-    "description": "Greenwich Mean Time",
-    "offset": 0
-  },
-  {
-    "name": "Africa/Lome",
-    "description": "Greenwich Mean Time",
-    "offset": 0
-  },
-  {
-    "name": "Africa/Ouagadougou",
-    "description": "Greenwich Mean Time",
-    "offset": 0
-  },
-  {
-    "name": "GMT",
-    "description": "Greenwich Mean Time",
-    "offset": 0
-  },
-  {
-    "name": "Africa/Banjul",
-    "description": "Greenwich Mean Time",
-    "offset": 0
-  },
-  {
-    "name": "Atlantic/Reykjavik",
-    "description": "Greenwich Mean Time",
-    "offset": 0
-  },
-  {
-    "name": "Africa/Timbuktu",
-    "description": "Greenwich Mean Time",
-    "offset": 0
-  },
-  {
-    "name": "GMT+0",
-    "description": "Greenwich Mean Time",
-    "offset": 0
-  },
-  {
-    "name": "Etc/GMT-0",
+    "name": "Africa/Abidjan",
     "description": "Greenwich Mean Time",
     "offset": 0
   },
@@ -1890,7 +1820,47 @@
     "offset": 0
   },
   {
+    "name": "Africa/Banjul",
+    "description": "Greenwich Mean Time",
+    "offset": 0
+  },
+  {
+    "name": "Africa/Bissau",
+    "description": "Greenwich Mean Time",
+    "offset": 0
+  },
+  {
+    "name": "Africa/Conakry",
+    "description": "Greenwich Mean Time",
+    "offset": 0
+  },
+  {
+    "name": "Africa/Dakar",
+    "description": "Greenwich Mean Time",
+    "offset": 0
+  },
+  {
+    "name": "Africa/Freetown",
+    "description": "Greenwich Mean Time",
+    "offset": 0
+  },
+  {
+    "name": "Africa/Lome",
+    "description": "Greenwich Mean Time",
+    "offset": 0
+  },
+  {
+    "name": "Africa/Monrovia",
+    "description": "Greenwich Mean Time",
+    "offset": 0
+  },
+  {
     "name": "Africa/Nouakchott",
+    "description": "Greenwich Mean Time",
+    "offset": 0
+  },
+  {
+    "name": "Africa/Ouagadougou",
     "description": "Greenwich Mean Time",
     "offset": 0
   },
@@ -1900,12 +1870,22 @@
     "offset": 0
   },
   {
-    "name": "Atlantic/St_Helena",
+    "name": "Africa/Timbuktu",
     "description": "Greenwich Mean Time",
     "offset": 0
   },
   {
-    "name": "Africa/Abidjan",
+    "name": "America/Danmarkshavn",
+    "description": "Greenwich Mean Time",
+    "offset": 0
+  },
+  {
+    "name": "Atlantic/Reykjavik",
+    "description": "Greenwich Mean Time",
+    "offset": 0
+  },
+  {
+    "name": "Atlantic/St_Helena",
     "description": "Greenwich Mean Time",
     "offset": 0
   },
@@ -1916,6 +1896,31 @@
   },
   {
     "name": "Etc/GMT+0",
+    "description": "Greenwich Mean Time",
+    "offset": 0
+  },
+  {
+    "name": "Etc/GMT-0",
+    "description": "Greenwich Mean Time",
+    "offset": 0
+  },
+  {
+    "name": "Etc/GMT0",
+    "description": "Greenwich Mean Time",
+    "offset": 0
+  },
+  {
+    "name": "Etc/Greenwich",
+    "description": "Greenwich Mean Time",
+    "offset": 0
+  },
+  {
+    "name": "GMT",
+    "description": "Greenwich Mean Time",
+    "offset": 0
+  },
+  {
+    "name": "GMT+0",
     "description": "Greenwich Mean Time",
     "offset": 0
   },
@@ -1935,22 +1940,17 @@
     "offset": 0
   },
   {
-    "name": "Africa/Conakry",
+    "name": "Iceland",
     "description": "Greenwich Mean Time",
     "offset": 0
   },
   {
-    "name": "America/Danmarkshavn",
-    "description": "Greenwich Mean Time",
-    "offset": 0
-  },
-  {
-    "name": "Asia/Muscat",
+    "name": "Asia/Dubai",
     "description": "Gulf Standard Time",
     "offset": 240
   },
   {
-    "name": "Asia/Dubai",
+    "name": "Asia/Muscat",
     "description": "Gulf Standard Time",
     "offset": 240
   },
@@ -1960,7 +1960,7 @@
     "offset": -240
   },
   {
-    "name": "US/Aleutian",
+    "name": "America/Adak",
     "description": "Hawaii Daylight Time",
     "offset": -540
   },
@@ -1970,17 +1970,17 @@
     "offset": -540
   },
   {
-    "name": "America/Adak",
+    "name": "US/Aleutian",
     "description": "Hawaii Daylight Time",
     "offset": -540
   },
   {
-    "name": "US/Hawaii",
+    "name": "HST",
     "description": "Hawaii Standard Time",
     "offset": -600
   },
   {
-    "name": "HST",
+    "name": "Pacific/Honolulu",
     "description": "Hawaii Standard Time",
     "offset": -600
   },
@@ -1990,7 +1990,7 @@
     "offset": -600
   },
   {
-    "name": "Pacific/Honolulu",
+    "name": "US/Hawaii",
     "description": "Hawaii Standard Time",
     "offset": -600
   },
@@ -2010,7 +2010,7 @@
     "offset": 480
   },
   {
-    "name": "Asia/Kolkata",
+    "name": "Asia/Calcutta",
     "description": "India Standard Time",
     "offset": 330
   },
@@ -2020,7 +2020,7 @@
     "offset": 330
   },
   {
-    "name": "Asia/Calcutta",
+    "name": "Asia/Kolkata",
     "description": "India Standard Time",
     "offset": 330
   },
@@ -2028,11 +2028,6 @@
     "name": "Indian/Chagos",
     "description": "Indian Ocean Territory Time",
     "offset": 360
-  },
-  {
-    "name": "Asia/Phnom_Penh",
-    "description": "Indochina Time",
-    "offset": 420
   },
   {
     "name": "Asia/Bangkok",
@@ -2045,7 +2040,7 @@
     "offset": 420
   },
   {
-    "name": "Asia/Vientiane",
+    "name": "Asia/Phnom_Penh",
     "description": "Indochina Time",
     "offset": 420
   },
@@ -2055,12 +2050,17 @@
     "offset": 420
   },
   {
-    "name": "Iran",
+    "name": "Asia/Vientiane",
+    "description": "Indochina Time",
+    "offset": 420
+  },
+  {
+    "name": "Asia/Tehran",
     "description": "Iran Daylight Time",
     "offset": 270
   },
   {
-    "name": "Asia/Tehran",
+    "name": "Iran",
     "description": "Iran Daylight Time",
     "offset": 270
   },
@@ -2075,12 +2075,12 @@
     "offset": 60
   },
   {
-    "name": "Asia/Irkutsk",
+    "name": "Asia/Chita",
     "description": "Irkutsk Time",
     "offset": 480
   },
   {
-    "name": "Asia/Chita",
+    "name": "Asia/Irkutsk",
     "description": "Irkutsk Time",
     "offset": 480
   },
@@ -2125,12 +2125,12 @@
     "offset": 540
   },
   {
-    "name": "ROK",
+    "name": "Asia/Seoul",
     "description": "Korea Standard Time",
     "offset": 540
   },
   {
-    "name": "Asia/Seoul",
+    "name": "ROK",
     "description": "Korea Standard Time",
     "offset": 540
   },
@@ -2155,12 +2155,12 @@
     "offset": 840
   },
   {
-    "name": "Australia/Lord_Howe",
+    "name": "Australia/LHI",
     "description": "Lord Howe Standard Time",
     "offset": 630
   },
   {
-    "name": "Australia/LHI",
+    "name": "Australia/Lord_Howe",
     "description": "Lord Howe Standard Time",
     "offset": 630
   },
@@ -2225,22 +2225,12 @@
     "offset": 120
   },
   {
-    "name": "Europe/Moscow",
-    "description": "Moscow Standard Time",
-    "offset": 180
-  },
-  {
-    "name": "W-SU",
-    "description": "Moscow Standard Time",
-    "offset": 180
-  },
-  {
     "name": "Europe/Minsk",
     "description": "Moscow Standard Time",
     "offset": 180
   },
   {
-    "name": "Europe/Volgograd",
+    "name": "Europe/Moscow",
     "description": "Moscow Standard Time",
     "offset": 180
   },
@@ -2250,67 +2240,17 @@
     "offset": 180
   },
   {
-    "name": "US/Mountain",
-    "description": "Mountain Daylight Time",
-    "offset": -360
+    "name": "Europe/Volgograd",
+    "description": "Moscow Standard Time",
+    "offset": 180
   },
   {
-    "name": "Mexico/BajaSur",
-    "description": "Mountain Daylight Time",
-    "offset": -360
-  },
-  {
-    "name": "Canada/Mountain",
-    "description": "Mountain Daylight Time",
-    "offset": -360
-  },
-  {
-    "name": "America/Inuvik",
-    "description": "Mountain Daylight Time",
-    "offset": -360
-  },
-  {
-    "name": "America/Chihuahua",
-    "description": "Mountain Daylight Time",
-    "offset": -360
-  },
-  {
-    "name": "Navajo",
-    "description": "Mountain Daylight Time",
-    "offset": -360
-  },
-  {
-    "name": "America/Ojinaga",
-    "description": "Mountain Daylight Time",
-    "offset": -360
+    "name": "W-SU",
+    "description": "Moscow Standard Time",
+    "offset": 180
   },
   {
     "name": "America/Boise",
-    "description": "Mountain Daylight Time",
-    "offset": -360
-  },
-  {
-    "name": "America/Denver",
-    "description": "Mountain Daylight Time",
-    "offset": -360
-  },
-  {
-    "name": "MST7MDT",
-    "description": "Mountain Daylight Time",
-    "offset": -360
-  },
-  {
-    "name": "America/Yellowknife",
-    "description": "Mountain Daylight Time",
-    "offset": -360
-  },
-  {
-    "name": "America/Edmonton",
-    "description": "Mountain Daylight Time",
-    "offset": -360
-  },
-  {
-    "name": "America/Shiprock",
     "description": "Mountain Daylight Time",
     "offset": -360
   },
@@ -2320,19 +2260,69 @@
     "offset": -360
   },
   {
+    "name": "America/Chihuahua",
+    "description": "Mountain Daylight Time",
+    "offset": -360
+  },
+  {
+    "name": "America/Denver",
+    "description": "Mountain Daylight Time",
+    "offset": -360
+  },
+  {
+    "name": "America/Edmonton",
+    "description": "Mountain Daylight Time",
+    "offset": -360
+  },
+  {
+    "name": "America/Inuvik",
+    "description": "Mountain Daylight Time",
+    "offset": -360
+  },
+  {
     "name": "America/Mazatlan",
     "description": "Mountain Daylight Time",
     "offset": -360
   },
   {
-    "name": "America/Dawson_Creek",
-    "description": "Mountain Standard Time",
-    "offset": -420
+    "name": "America/Ojinaga",
+    "description": "Mountain Daylight Time",
+    "offset": -360
   },
   {
-    "name": "US/Arizona",
-    "description": "Mountain Standard Time",
-    "offset": -420
+    "name": "America/Shiprock",
+    "description": "Mountain Daylight Time",
+    "offset": -360
+  },
+  {
+    "name": "America/Yellowknife",
+    "description": "Mountain Daylight Time",
+    "offset": -360
+  },
+  {
+    "name": "Canada/Mountain",
+    "description": "Mountain Daylight Time",
+    "offset": -360
+  },
+  {
+    "name": "Mexico/BajaSur",
+    "description": "Mountain Daylight Time",
+    "offset": -360
+  },
+  {
+    "name": "MST7MDT",
+    "description": "Mountain Daylight Time",
+    "offset": -360
+  },
+  {
+    "name": "Navajo",
+    "description": "Mountain Daylight Time",
+    "offset": -360
+  },
+  {
+    "name": "US/Mountain",
+    "description": "Mountain Daylight Time",
+    "offset": -360
   },
   {
     "name": "America/Creston",
@@ -2340,7 +2330,7 @@
     "offset": -420
   },
   {
-    "name": "America/Phoenix",
+    "name": "America/Dawson_Creek",
     "description": "Mountain Standard Time",
     "offset": -420
   },
@@ -2350,7 +2340,17 @@
     "offset": -420
   },
   {
+    "name": "America/Phoenix",
+    "description": "Mountain Standard Time",
+    "offset": -420
+  },
+  {
     "name": "MST",
+    "description": "Mountain Standard Time",
+    "offset": -420
+  },
+  {
+    "name": "US/Arizona",
     "description": "Mountain Standard Time",
     "offset": -420
   },
@@ -2365,12 +2365,12 @@
     "offset": 720
   },
   {
-    "name": "Asia/Katmandu",
+    "name": "Asia/Kathmandu",
     "description": "Nepal Time",
     "offset": 345
   },
   {
-    "name": "Asia/Kathmandu",
+    "name": "Asia/Katmandu",
     "description": "Nepal Time",
     "offset": 345
   },
@@ -2380,7 +2380,7 @@
     "offset": 660
   },
   {
-    "name": "Pacific/Auckland",
+    "name": "Antarctica/McMurdo",
     "description": "New Zealand Standard Time",
     "offset": 720
   },
@@ -2390,22 +2390,22 @@
     "offset": 720
   },
   {
-    "name": "Antarctica/McMurdo",
-    "description": "New Zealand Standard Time",
-    "offset": 720
-  },
-  {
     "name": "NZ",
     "description": "New Zealand Standard Time",
     "offset": 720
   },
   {
-    "name": "Canada/Newfoundland",
+    "name": "Pacific/Auckland",
+    "description": "New Zealand Standard Time",
+    "offset": 720
+  },
+  {
+    "name": "America/St_Johns",
     "description": "Newfoundland Daylight Time",
     "offset": -150
   },
   {
-    "name": "America/St_Johns",
+    "name": "Canada/Newfoundland",
     "description": "Newfoundland Daylight Time",
     "offset": -150
   },
@@ -2435,7 +2435,7 @@
     "offset": 300
   },
   {
-    "name": "Canada/Yukon",
+    "name": "America/Dawson",
     "description": "Pacific Daylight Time",
     "offset": -420
   },
@@ -2445,32 +2445,17 @@
     "offset": -420
   },
   {
+    "name": "America/Los_Angeles",
+    "description": "Pacific Daylight Time",
+    "offset": -420
+  },
+  {
     "name": "America/Santa_Isabel",
     "description": "Pacific Daylight Time",
     "offset": -420
   },
   {
-    "name": "Mexico/BajaNorte",
-    "description": "Pacific Daylight Time",
-    "offset": -420
-  },
-  {
-    "name": "US/Pacific",
-    "description": "Pacific Daylight Time",
-    "offset": -420
-  },
-  {
     "name": "America/Tijuana",
-    "description": "Pacific Daylight Time",
-    "offset": -420
-  },
-  {
-    "name": "US/Pacific-New",
-    "description": "Pacific Daylight Time",
-    "offset": -420
-  },
-  {
-    "name": "America/Los_Angeles",
     "description": "Pacific Daylight Time",
     "offset": -420
   },
@@ -2485,17 +2470,32 @@
     "offset": -420
   },
   {
-    "name": "PST8PDT",
-    "description": "Pacific Daylight Time",
-    "offset": -420
-  },
-  {
     "name": "Canada/Pacific",
     "description": "Pacific Daylight Time",
     "offset": -420
   },
   {
-    "name": "America/Dawson",
+    "name": "Canada/Yukon",
+    "description": "Pacific Daylight Time",
+    "offset": -420
+  },
+  {
+    "name": "Mexico/BajaNorte",
+    "description": "Pacific Daylight Time",
+    "offset": -420
+  },
+  {
+    "name": "PST8PDT",
+    "description": "Pacific Daylight Time",
+    "offset": -420
+  },
+  {
+    "name": "US/Pacific",
+    "description": "Pacific Daylight Time",
+    "offset": -420
+  },
+  {
+    "name": "US/Pacific-New",
     "description": "Pacific Daylight Time",
     "offset": -420
   },
@@ -2555,12 +2555,12 @@
     "offset": -480
   },
   {
-    "name": "Pacific/Ponape",
+    "name": "Pacific/Pohnpei",
     "description": "Pohnpei Time",
     "offset": 660
   },
   {
-    "name": "Pacific/Pohnpei",
+    "name": "Pacific/Ponape",
     "description": "Pohnpei Time",
     "offset": 660
   },
@@ -2600,12 +2600,12 @@
     "offset": -660
   },
   {
-    "name": "US/Samoa",
+    "name": "Pacific/Samoa",
     "description": "Samoa Standard Time",
     "offset": -660
   },
   {
-    "name": "Pacific/Samoa",
+    "name": "US/Samoa",
     "description": "Samoa Standard Time",
     "offset": -660
   },
@@ -2615,12 +2615,12 @@
     "offset": 240
   },
   {
-    "name": "Singapore",
+    "name": "Asia/Singapore",
     "description": "Singapore Time",
     "offset": 480
   },
   {
-    "name": "Asia/Singapore",
+    "name": "Singapore",
     "description": "Singapore Time",
     "offset": 480
   },
@@ -2630,17 +2630,17 @@
     "offset": 660
   },
   {
+    "name": "Africa/Johannesburg",
+    "description": "South Africa Standard Time",
+    "offset": 120
+  },
+  {
     "name": "Africa/Maseru",
     "description": "South Africa Standard Time",
     "offset": 120
   },
   {
     "name": "Africa/Mbabane",
-    "description": "South Africa Standard Time",
-    "offset": 120
-  },
-  {
-    "name": "Africa/Johannesburg",
     "description": "South Africa Standard Time",
     "offset": 120
   },
@@ -2690,12 +2690,12 @@
     "offset": 780
   },
   {
-    "name": "Asia/Ashkhabad",
+    "name": "Asia/Ashgabat",
     "description": "Turkmenistan Time",
     "offset": 300
   },
   {
-    "name": "Asia/Ashgabat",
+    "name": "Asia/Ashkhabad",
     "description": "Turkmenistan Time",
     "offset": 300
   },
@@ -2705,12 +2705,12 @@
     "offset": 720
   },
   {
-    "name": "Asia/Ulan_Bator",
+    "name": "Asia/Ulaanbaatar",
     "description": "Ulaanbaatar Summer Time",
     "offset": 540
   },
   {
-    "name": "Asia/Ulaanbaatar",
+    "name": "Asia/Ulan_Bator",
     "description": "Ulaanbaatar Summer Time",
     "offset": 540
   },
@@ -2725,12 +2725,12 @@
     "offset": 600
   },
   {
-    "name": "Asia/Tashkent",
+    "name": "Asia/Samarkand",
     "description": "Uzbekistan Time",
     "offset": 300
   },
   {
-    "name": "Asia/Samarkand",
+    "name": "Asia/Tashkent",
     "description": "Uzbekistan Time",
     "offset": 300
   },
@@ -2780,27 +2780,7 @@
     "offset": 780
   },
   {
-    "name": "Africa/Kinshasa",
-    "description": "Western African Time",
-    "offset": 60
-  },
-  {
-    "name": "Africa/Douala",
-    "description": "Western African Time",
-    "offset": 60
-  },
-  {
-    "name": "Africa/Ndjamena",
-    "description": "Western African Time",
-    "offset": 60
-  },
-  {
     "name": "Africa/Bangui",
-    "description": "Western African Time",
-    "offset": 60
-  },
-  {
-    "name": "Africa/Malabo",
     "description": "Western African Time",
     "offset": 60
   },
@@ -2810,12 +2790,42 @@
     "offset": 60
   },
   {
-    "name": "Africa/Niamey",
+    "name": "Africa/Douala",
+    "description": "Western African Time",
+    "offset": 60
+  },
+  {
+    "name": "Africa/Kinshasa",
     "description": "Western African Time",
     "offset": 60
   },
   {
     "name": "Africa/Lagos",
+    "description": "Western African Time",
+    "offset": 60
+  },
+  {
+    "name": "Africa/Libreville",
+    "description": "Western African Time",
+    "offset": 60
+  },
+  {
+    "name": "Africa/Luanda",
+    "description": "Western African Time",
+    "offset": 60
+  },
+  {
+    "name": "Africa/Malabo",
+    "description": "Western African Time",
+    "offset": 60
+  },
+  {
+    "name": "Africa/Ndjamena",
+    "description": "Western African Time",
+    "offset": 60
+  },
+  {
+    "name": "Africa/Niamey",
     "description": "Western African Time",
     "offset": 60
   },
@@ -2830,17 +2840,17 @@
     "offset": 60
   },
   {
-    "name": "Africa/Luanda",
-    "description": "Western African Time",
-    "offset": 60
-  },
-  {
-    "name": "Africa/Libreville",
-    "description": "Western African Time",
-    "offset": 60
-  },
-  {
     "name": "Africa/Casablanca",
+    "description": "Western European Summer Time",
+    "offset": 60
+  },
+  {
+    "name": "Africa/El_Aaiun",
+    "description": "Western European Summer Time",
+    "offset": 60
+  },
+  {
+    "name": "Atlantic/Canary",
     "description": "Western European Summer Time",
     "offset": 60
   },
@@ -2850,17 +2860,12 @@
     "offset": 60
   },
   {
+    "name": "Atlantic/Faroe",
+    "description": "Western European Summer Time",
+    "offset": 60
+  },
+  {
     "name": "Atlantic/Madeira",
-    "description": "Western European Summer Time",
-    "offset": 60
-  },
-  {
-    "name": "WET",
-    "description": "Western European Summer Time",
-    "offset": 60
-  },
-  {
-    "name": "Africa/El_Aaiun",
     "description": "Western European Summer Time",
     "offset": 60
   },
@@ -2875,12 +2880,7 @@
     "offset": 60
   },
   {
-    "name": "Atlantic/Canary",
-    "description": "Western European Summer Time",
-    "offset": 60
-  },
-  {
-    "name": "Atlantic/Faroe",
+    "name": "WET",
     "description": "Western European Summer Time",
     "offset": 60
   },
@@ -2890,12 +2890,12 @@
     "offset": -120
   },
   {
-    "name": "Asia/Urumqi",
+    "name": "Asia/Kashgar",
     "description": "Xinjiang Standard Time",
     "offset": 360
   },
   {
-    "name": "Asia/Kashgar",
+    "name": "Asia/Urumqi",
     "description": "Xinjiang Standard Time",
     "offset": 360
   },

--- a/data/javascript/currency-format.v2.json
+++ b/data/javascript/currency-format.v2.json
@@ -2492,7 +2492,7 @@
   "pt-ST": {
     "symbol": {
       "primary": "STD",
-      "narrow": "Db"
+      "narrow": "STD"
     },
     "decimal": ",",
     "group": " ",

--- a/final/final.go
+++ b/final/final.go
@@ -853,10 +853,26 @@ func sortLocales(locales []common.Locale) []common.Locale {
 	return locales
 }
 
+// https://stackoverflow.com/a/36122804/2297665
+type byDescriptionAndName []common.Timezone
+
+func (tz byDescriptionAndName) Len() int      { return len(tz) }
+func (tz byDescriptionAndName) Swap(i, j int) { tz[i], tz[j] = tz[j], tz[i] }
+
+// Sort by description first, then name (description is not unique)
+func (tz byDescriptionAndName) Less(i, j int) bool {
+	if strings.ToLower(tz[i].Description) < strings.ToLower(tz[j].Description) {
+		return true
+	}
+	if strings.ToLower(tz[i].Description) > strings.ToLower(tz[j].Description) {
+		return false
+	}
+
+	return strings.ToLower(tz[i].Name) < strings.ToLower(tz[j].Name)
+}
+
 func sortTimezones(timezones []common.Timezone) []common.Timezone {
-	slice.Sort(timezones[:], func(i, j int) bool {
-		return strings.ToLower(timezones[i].Description) < strings.ToLower(timezones[j].Description)
-	})
+	sort.Sort(byDescriptionAndName(timezones))
 	return timezones
 }
 


### PR DESCRIPTION
Timezone descriptions are not unique, so sorting by the description is nondeterministic. This change fixes the issue by adding an additional sort on the timezone name.