### PR TITLE
Add Klarna payment method

### DIFF
--- a/data/cleansed/payment-methods.json
+++ b/data/cleansed/payment-methods.json
@@ -166,7 +166,21 @@
     "large_width": 256,
     "large_height": 256,
     "regions": [
-      "jpn"
+      "world"
+    ]
+  },
+  {
+    "id": "klarna",
+    "type": "online",
+    "name": "Klarna",
+    "small_width": 65,
+    "small_height": 41,
+    "medium_width": 100,
+    "medium_height": 60,
+    "large_width": 256,
+    "large_height": 256,
+    "regions": [
+      "world"
     ]
   },
   {

--- a/data/final/payment-methods.json
+++ b/data/final/payment-methods.json
@@ -302,6 +302,31 @@
     ]
   },
   {
+    "id": "klarna",
+    "type": "online",
+    "name": "Klarna",
+    "images": {
+      "small": {
+        "url": "https://flowcdn.io/util/logos/payment-methods/klarna/30/original.png",
+        "width": 65,
+        "height": 41
+      },
+      "medium": {
+        "url": "https://flowcdn.io/util/logos/payment-methods/klarna/60/original.png",
+        "width": 100,
+        "height": 60
+      },
+      "large": {
+        "url": "https://flowcdn.io/util/logos/payment-methods/klarna/120/original.png",
+        "width": 256,
+        "height": 256
+      }
+    },
+    "regions": [
+      "world"
+    ]
+  },
+  {
     "id": "maestro",
     "type": "card",
     "name": "Maestro",

--- a/data/original/payment-methods.csv
+++ b/data/original/payment-methods.csv
@@ -9,13 +9,14 @@ card,jcb,Jcb,65,41,100,60,256,256,jpn
 card,maestro,Maestro,65,41,100,60,256,256,north-america europe
 card,mastercard,Mastercard,65,41,100,60,256,256,world
 card,visa,VISA,65,41,100,60,256,256,world
-online,paypal,PayPal,65,41,100,60,180,60,world
-online,unionpay,UnionPay,65,41,100,60,256,256,world
 online,alipay,Alipay,65,41,100,60,256,256,world
+online,bitcoin,Bitcoin,65,41,100,60,256,256,world
 online,directEbanking,Sofortüberweisung,65,41,100,60,256,256,world
 online,giropay,GiroPay,65,41,100,60,256,256,world
-online,wechatpay,WeChat Pay,65,41,100,60,256,256,world
+online,ideal,iDEAL,65,41,100,60,256,256,world
+online,klarna,Klarna,65,41,100,60,256,256,world
+online,paypal,PayPal,65,41,100,60,180,60,world
 online,qiwiwallet,Qiwi Wallet,65,41,100,60,256,256,world
 online,sepadirectdebit,SEPA Direct Debit,65,41,100,60,256,256,world
-online,ideal,iDEAL,65,41,100,60,256,256,world
-online,bitcoin,Bitcoin,65,41,100,60,256,256,world
+online,unionpay,UnionPay,65,41,100,60,256,256,world
+online,wechatpay,WeChat Pay,65,41,100,60,256,256,world


### PR DESCRIPTION
I'm unsure about the `regions`. I set to `world` but according to Stripe doc, Klarna payment can be made using the following currencies:

* EUR
* SEK
* NOK
* DKK
* GBP
* USD

I'm wondering if the `regions` setting should somehow match these?