### PR TITLE
[PATCH] Translate 'el' to 'gr' so locale country code is valid

### DIFF
--- a/final/final.go
+++ b/final/final.go
@@ -160,6 +160,7 @@ func commonLocales(data CleansedDataSet) []common.Locale {
 
 	countryMap := map[string]string{
 		"zh": "cn",
+		"el": "gr",
 	}
 
 	unsupportedLanguages := []string{


### PR DESCRIPTION
Intended to address client issue:

```
SI is trying to use the currency formatting utility offered by Flow.js, which relies on the locale returned
by session. When the session is updated to France, the locale from session is correctly identified as
 `fr` and therefore the utility formats currency in euros. However, when session is updated to Greece, the locale inferred is `en_US`.
```