### PR TITLE
Add catch-all  carrier and service levels

### DIFF
--- a/data/cleansed/carrier-services.json
+++ b/data/cleansed/carrier-services.json
@@ -100,6 +100,21 @@
     "carrier_id": "landmark"
   },
   {
+    "id": "other-freight",
+    "name": "Freight",
+    "carrier_id": "other"
+  },
+  {
+    "id": "other-ltl",
+    "name": "Less Than Truckload",
+    "carrier_id": "other"
+  },
+  {
+    "id": "other-postal",
+    "name": "Postal",
+    "carrier_id": "other"
+  },
+  {
     "id": "sf-express-economy-express-parcel",
     "name": "Economy Express Parcel",
     "carrier_id": "sf-express"

--- a/data/cleansed/carriers.json
+++ b/data/cleansed/carriers.json
@@ -50,6 +50,11 @@
     "tracking_url": "https://track.landmarkglobal.com/?trck="
   },
   {
+    "id": "other",
+    "name": "Other",
+    "tracking_url": "https://track.flow.io/"
+  },
+  {
     "id": "sf-express",
     "name": "SF Express",
     "tracking_url": "http://www.sf-express.com/us/en/dynamic_function/waybill/#search/bill-number/"

--- a/data/final/carrier-services.json
+++ b/data/final/carrier-services.json
@@ -180,6 +180,33 @@
     }
   },
   {
+    "id": "other-freight",
+    "name": "Freight",
+    "carrier": {
+      "id": "other",
+      "name": "Other",
+      "tracking_url": "https://track.flow.io/"
+    }
+  },
+  {
+    "id": "other-ltl",
+    "name": "Less Than Truckload",
+    "carrier": {
+      "id": "other",
+      "name": "Other",
+      "tracking_url": "https://track.flow.io/"
+    }
+  },
+  {
+    "id": "other-postal",
+    "name": "Postal",
+    "carrier": {
+      "id": "other",
+      "name": "Other",
+      "tracking_url": "https://track.flow.io/"
+    }
+  },
+  {
     "id": "sf-express-economy-express-parcel",
     "name": "Economy Express Parcel",
     "carrier": {

--- a/data/final/carriers.json
+++ b/data/final/carriers.json
@@ -50,6 +50,11 @@
     "tracking_url": "https://track.landmarkglobal.com/?trck="
   },
   {
+    "id": "other",
+    "name": "Other",
+    "tracking_url": "https://track.flow.io/"
+  },
+  {
     "id": "sf-express",
     "name": "SF Express",
     "tracking_url": "http://www.sf-express.com/us/en/dynamic_function/waybill/#search/bill-number/"

--- a/data/original/carrier-services.csv
+++ b/data/original/carrier-services.csv
@@ -19,6 +19,9 @@ la-poste-colissimo,Colissimo,la-poste
 ilg-european-single-pack,European Single Pack,ilg
 ilg-global-courier,Global Courier,ilg
 ilg-international-courier,International Courier,ilg
+other-freight,Freight,other
+other-ltl,Less Than Truckload,other
+other-postal,Postal,other
 sf-express-economy-express-parcel,Economy Express Parcel,sf-express
 ups-ground,Ground,ups
 ups-international-import,International Import,ups

--- a/data/original/carriers.csv
+++ b/data/original/carriers.csv
@@ -5,6 +5,7 @@ dhl,DHL Express,http://www.dhl.com/en/express/tracking.html?AWB=
 dhl-ecommerce,DHL Ecommerce,https://webtrack.dhlglobalmail.com/?trackingnumber=
 dhl-global-mail,DHL Global Mail,https://webtrack.dhlglobalmail.com/?trackingnumber=
 dhl-parcel,DHL Parcel,https://webtrack.dhlglobalmail.com/?trackingnumber=
+other,Other,https://track.flow.io/
 fedex,FedEx,https://www.fedex.com/apps/fedextrack/?tracknumbers=
 ilg,ILG,https://www.ilguk.com/track-trace/
 landmark,Landmark,https://track.landmarkglobal.com/?trck=


### PR DESCRIPTION
I need a way to capture internally-generated tracking barcodes for purposes of tracking a domestic shipment to a crossdock. For the case of stadium goods and possibly other high-volume domestic merchants, they will choose to paletize and generate an internal barcode for notification purposes for the crossdock. This is used interchangeably with in our API and means the domestic shipment can be "tracked".