### PR TITLE
[CHEC-570][Payment Methods] Add Capabilities

### DIFF
--- a/cleanse/cleanse.go
+++ b/cleanse/cleanse.go
@@ -169,6 +169,7 @@ type PaymentMethod struct {
 	LargeWidth   int      `json:"large_width"`
 	LargeHeight  int      `json:"large_height"`
 	Regions      []string `json:"regions"`
+	Capabilities []string `json:"capabilities"`
 }
 
 type Separators struct {
@@ -392,6 +393,9 @@ func Cleanse() {
 		),
 	)
 
+	splitCapabilities := func(c rune) bool {
+		return c == ' '
+	}
 	writeJson("data/cleansed/payment-methods.json",
 		toObjects(readCsv("data/original/payment-methods.csv"),
 			func(record map[string]string) bool {
@@ -409,6 +413,7 @@ func Cleanse() {
 					LargeWidth:   toInt32(record["large_width"]),
 					LargeHeight:  toInt32(record["large_height"]),
 					Regions:      strings.Split(record["regions"], " "),
+					Capabilities:	strings.FieldsFunc(record["capabilities"], splitCapabilities),
 				}
 			},
 			func(record map[string]string) string {

--- a/common/common.go
+++ b/common/common.go
@@ -65,11 +65,12 @@ type Language struct {
 }
 
 type PaymentMethod struct {
-	Id      string              `json:"id"`
-	Type    string              `json:"type"`
-	Name    string              `json:"name"`
-	Images  PaymentMethodImages `json:"images"`
-	Regions []string            `json:"regions"`
+	Id      				string              		`json:"id"`
+	Type    				string              		`json:"type"`
+	Name    				string              		`json:"name"`
+	Images  				PaymentMethodImages 		`json:"images"`
+	Regions 				[]string            		`json:"regions"`
+	Capabilities		[]string		            `json:"capabilities"`
 }
 
 type PaymentMethodImages struct {

--- a/data/cleansed/payment-methods.json
+++ b/data/cleansed/payment-methods.json
@@ -11,7 +11,8 @@
     "large_height": 256,
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "afterpay",
@@ -25,7 +26,8 @@
     "large_height": 256,
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "alipay",
@@ -39,7 +41,8 @@
     "large_height": 256,
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "american_express",
@@ -53,6 +56,9 @@
     "large_height": 256,
     "regions": [
       "world"
+    ],
+    "capabilities": [
+      "credit"
     ]
   },
   {
@@ -67,7 +73,8 @@
     "large_height": 256,
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "bankTransfer_IBAN",
@@ -81,7 +88,8 @@
     "large_height": 256,
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "bitcoin",
@@ -95,7 +103,8 @@
     "large_height": 256,
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "bitpay",
@@ -109,7 +118,8 @@
     "large_height": 256,
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "cartes_bancaires",
@@ -123,6 +133,9 @@
     "large_height": 256,
     "regions": [
       "fra"
+    ],
+    "capabilities": [
+      "credit"
     ]
   },
   {
@@ -137,6 +150,10 @@
     "large_height": 256,
     "regions": [
       "chn"
+    ],
+    "capabilities": [
+      "credit",
+      "debit"
     ]
   },
   {
@@ -151,7 +168,8 @@
     "large_height": 256,
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "dankort",
@@ -165,6 +183,9 @@
     "large_height": 256,
     "regions": [
       "europe"
+    ],
+    "capabilities": [
+      "debit"
     ]
   },
   {
@@ -180,6 +201,9 @@
     "regions": [
       "north-america",
       "europe"
+    ],
+    "capabilities": [
+      "credit"
     ]
   },
   {
@@ -194,7 +218,8 @@
     "large_height": 256,
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "discover",
@@ -209,6 +234,9 @@
     "regions": [
       "north-america",
       "europe"
+    ],
+    "capabilities": [
+      "credit"
     ]
   },
   {
@@ -223,7 +251,8 @@
     "large_height": 256,
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "dragonpay_ebanking",
@@ -237,7 +266,8 @@
     "large_height": 256,
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "dragonpay_gcash",
@@ -251,7 +281,8 @@
     "large_height": 256,
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "dragonpay_otc_banking",
@@ -265,7 +296,8 @@
     "large_height": 256,
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "ebanking_FI",
@@ -279,7 +311,8 @@
     "large_height": 256,
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "giropay",
@@ -293,7 +326,8 @@
     "large_height": 256,
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "google_pay",
@@ -307,7 +341,8 @@
     "large_height": 256,
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "ideal",
@@ -321,7 +356,8 @@
     "large_height": 256,
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "interac",
@@ -335,7 +371,8 @@
     "large_height": 256,
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "jcb",
@@ -349,6 +386,10 @@
     "large_height": 256,
     "regions": [
       "jpn"
+    ],
+    "capabilities": [
+      "credit",
+      "debit"
     ]
   },
   {
@@ -363,7 +404,8 @@
     "large_height": 256,
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "kcp_creditcard",
@@ -377,7 +419,8 @@
     "large_height": 256,
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "kcp_payco",
@@ -391,7 +434,8 @@
     "large_height": 256,
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "klarna",
@@ -405,7 +449,8 @@
     "large_height": 256,
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "maestro",
@@ -420,6 +465,9 @@
     "regions": [
       "north-america",
       "europe"
+    ],
+    "capabilities": [
+      "debit"
     ]
   },
   {
@@ -434,6 +482,10 @@
     "large_height": 256,
     "regions": [
       "world"
+    ],
+    "capabilities": [
+      "credit",
+      "debit"
     ]
   },
   {
@@ -448,7 +500,8 @@
     "large_height": 256,
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "multibanco",
@@ -462,7 +515,8 @@
     "large_height": 256,
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "paypal",
@@ -476,7 +530,8 @@
     "large_height": 60,
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "qiwiwallet",
@@ -490,7 +545,8 @@
     "large_height": 256,
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "sepadirectdebit",
@@ -504,7 +560,8 @@
     "large_height": 256,
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "trustly",
@@ -518,7 +575,8 @@
     "large_height": 256,
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "trustpay",
@@ -532,7 +590,8 @@
     "large_height": 256,
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "unionpay",
@@ -546,7 +605,8 @@
     "large_height": 256,
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "visa",
@@ -560,6 +620,10 @@
     "large_height": 256,
     "regions": [
       "world"
+    ],
+    "capabilities": [
+      "credit",
+      "debit"
     ]
   },
   {
@@ -574,6 +638,7 @@
     "large_height": 256,
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   }
 ]

--- a/data/final/payment-methods.json
+++ b/data/final/payment-methods.json
@@ -22,7 +22,8 @@
     },
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "afterpay",
@@ -47,7 +48,8 @@
     },
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "alipay",
@@ -72,7 +74,8 @@
     },
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "american_express",
@@ -97,6 +100,9 @@
     },
     "regions": [
       "world"
+    ],
+    "capabilities": [
+      "credit"
     ]
   },
   {
@@ -122,7 +128,8 @@
     },
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "bankTransfer_IBAN",
@@ -147,7 +154,8 @@
     },
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "bitcoin",
@@ -172,7 +180,8 @@
     },
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "bitpay",
@@ -197,7 +206,8 @@
     },
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "cartes_bancaires",
@@ -222,6 +232,9 @@
     },
     "regions": [
       "fra"
+    ],
+    "capabilities": [
+      "credit"
     ]
   },
   {
@@ -247,6 +260,10 @@
     },
     "regions": [
       "chn"
+    ],
+    "capabilities": [
+      "credit",
+      "debit"
     ]
   },
   {
@@ -272,7 +289,8 @@
     },
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "dankort",
@@ -297,6 +315,9 @@
     },
     "regions": [
       "europe"
+    ],
+    "capabilities": [
+      "debit"
     ]
   },
   {
@@ -323,6 +344,9 @@
     "regions": [
       "europe",
       "north-america"
+    ],
+    "capabilities": [
+      "credit"
     ]
   },
   {
@@ -348,7 +372,8 @@
     },
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "discover",
@@ -374,6 +399,9 @@
     "regions": [
       "europe",
       "north-america"
+    ],
+    "capabilities": [
+      "credit"
     ]
   },
   {
@@ -399,7 +427,8 @@
     },
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "dragonpay_ebanking",
@@ -424,7 +453,8 @@
     },
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "dragonpay_gcash",
@@ -449,7 +479,8 @@
     },
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "dragonpay_otc_banking",
@@ -474,7 +505,8 @@
     },
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "ebanking_FI",
@@ -499,7 +531,8 @@
     },
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "giropay",
@@ -524,7 +557,8 @@
     },
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "google_pay",
@@ -549,7 +583,8 @@
     },
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "ideal",
@@ -574,7 +609,8 @@
     },
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "interac",
@@ -599,7 +635,8 @@
     },
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "jcb",
@@ -624,6 +661,10 @@
     },
     "regions": [
       "jpn"
+    ],
+    "capabilities": [
+      "credit",
+      "debit"
     ]
   },
   {
@@ -649,7 +690,8 @@
     },
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "kcp_creditcard",
@@ -674,7 +716,8 @@
     },
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "kcp_payco",
@@ -699,7 +742,8 @@
     },
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "klarna",
@@ -724,7 +768,8 @@
     },
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "maestro",
@@ -750,6 +795,9 @@
     "regions": [
       "europe",
       "north-america"
+    ],
+    "capabilities": [
+      "debit"
     ]
   },
   {
@@ -775,6 +823,10 @@
     },
     "regions": [
       "world"
+    ],
+    "capabilities": [
+      "credit",
+      "debit"
     ]
   },
   {
@@ -800,7 +852,8 @@
     },
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "multibanco",
@@ -825,7 +878,8 @@
     },
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "paypal",
@@ -850,7 +904,8 @@
     },
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "qiwiwallet",
@@ -875,7 +930,8 @@
     },
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "sepadirectdebit",
@@ -900,7 +956,8 @@
     },
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "trustly",
@@ -925,7 +982,8 @@
     },
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "trustpay",
@@ -950,7 +1008,8 @@
     },
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "unionpay",
@@ -975,7 +1034,8 @@
     },
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   },
   {
     "id": "visa",
@@ -1000,6 +1060,10 @@
     },
     "regions": [
       "world"
+    ],
+    "capabilities": [
+      "credit",
+      "debit"
     ]
   },
   {
@@ -1025,6 +1089,7 @@
     },
     "regions": [
       "world"
-    ]
+    ],
+    "capabilities": []
   }
 ]

--- a/data/original/payment-methods.csv
+++ b/data/original/payment-methods.csv
@@ -1,42 +1,42 @@
-type,id,name,small_width,small_height,medium_width,medium_height,large_width,large_height,regions
-card,american_express,American Express,65,41,100,60,256,256,world
-card,cartes_bancaires,Cartes Bancaires,65,41,100,60,256,256,fra
-card,china_union_pay,China Union Pay,65,41,100,60,256,256,chn
-card,dankort,Dankort,65,41,100,60,256,256,europe
-card,diners_club,Diners Club,65,41,100,60,256,256,north-america europe
-card,discover,Discover,65,41,100,60,256,256,north-america europe
-card,jcb,Jcb,65,41,100,60,256,256,jpn
-card,maestro,Maestro,65,41,100,60,256,256,north-america europe
-card,mastercard,Mastercard,65,41,100,60,256,256,world
-card,visa,VISA,65,41,100,60,256,256,world
-online,ach,ACH,65,41,100,60,256,256,world
-online,alipay,Alipay,65,41,100,60,256,256,world
-online,afterpay,Afterpay,65,41,100,60,256,256,world
-online,apple_pay,Apple Pay,65,41,100,60,256,256,world
-online,bankTransfer_IBAN,International Bank Transfer (IBAN),65,41,100,60,256,256,world
-online,bitcoin,Bitcoin,65,41,100,60,256,256,world
-online,bitpay,BitPay,65,41,100,60,256,256,world
-online,cryptocom_pay,Crypto.com Pay,65,41,100,60,256,256,world
-online,directEbanking,Sofortüberweisung,65,41,100,60,256,256,world
-online,dotpay,Dotpay,65,41,100,60,256,256,world
-online,dragonpay_ebanking,Dragonpay eBanking,65,41,100,60,256,256,world
-online,dragonpay_gcash,GCash via Dragonpay,65,41,100,60,256,256,world
-online,dragonpay_otc_banking,Dragonpay OTC,65,41,100,60,256,256,world
-online,ebanking_FI,Finnish E-Banking,65,41,100,60,256,256,world
-online,giropay,GiroPay,65,41,100,60,256,256,world
-online,google_pay,Google Pay,65,41,100,60,256,256,world
-online,ideal,iDEAL,65,41,100,60,256,256,world
-online,interac,Interac Online,65,41,100,60,256,256,world
-online,kcp_banktransfer,Bank Transfer via KCP,65,41,100,60,256,256,world
-online,kcp_creditcard,Credit Card via KCP,65,41,100,60,256,256,world
-online,kcp_payco,PayCo,65,41,100,60,256,256,world
-online,klarna,Klarna,65,41,100,60,256,256,world
-online,molpay_points,MOLPoints via MOLPay,65,41,100,60,256,256,world
-online,multibanco,Multibanco,65,41,100,60,256,256,world
-online,paypal,PayPal,65,41,100,60,180,60,world
-online,qiwiwallet,Qiwi Wallet,65,41,100,60,256,256,world
-online,sepadirectdebit,SEPA Direct Debit,65,41,100,60,256,256,world
-online,trustly,Trustly,65,41,100,60,256,256,world
-online,trustpay,TrustPay,65,41,100,60,256,256,world
-online,unionpay,UnionPay,65,41,100,60,256,256,world
-online,wechatpay,WeChat Pay,65,41,100,60,256,256,world
+type,id,name,small_width,small_height,medium_width,medium_height,large_width,large_height,regions,capabilities
+card,american_express,American Express,65,41,100,60,256,256,world,credit
+card,cartes_bancaires,Cartes Bancaires,65,41,100,60,256,256,fra,credit
+card,china_union_pay,China Union Pay,65,41,100,60,256,256,chn,credit debit
+card,dankort,Dankort,65,41,100,60,256,256,europe,debit
+card,diners_club,Diners Club,65,41,100,60,256,256,north-america europe,credit
+card,discover,Discover,65,41,100,60,256,256,north-america europe,credit
+card,jcb,Jcb,65,41,100,60,256,256,jpn,credit debit
+card,maestro,Maestro,65,41,100,60,256,256,north-america europe,debit
+card,mastercard,Mastercard,65,41,100,60,256,256,world,credit debit
+card,visa,VISA,65,41,100,60,256,256,world,credit debit
+online,ach,ACH,65,41,100,60,256,256,world,
+online,alipay,Alipay,65,41,100,60,256,256,world,
+online,afterpay,Afterpay,65,41,100,60,256,256,world,
+online,apple_pay,Apple Pay,65,41,100,60,256,256,world,
+online,bankTransfer_IBAN,International Bank Transfer (IBAN),65,41,100,60,256,256,world,
+online,bitcoin,Bitcoin,65,41,100,60,256,256,world,
+online,bitpay,BitPay,65,41,100,60,256,256,world,
+online,cryptocom_pay,Crypto.com Pay,65,41,100,60,256,256,world,
+online,directEbanking,Sofortüberweisung,65,41,100,60,256,256,world,
+online,dotpay,Dotpay,65,41,100,60,256,256,world,
+online,dragonpay_ebanking,Dragonpay eBanking,65,41,100,60,256,256,world,
+online,dragonpay_gcash,GCash via Dragonpay,65,41,100,60,256,256,world,
+online,dragonpay_otc_banking,Dragonpay OTC,65,41,100,60,256,256,world,
+online,ebanking_FI,Finnish E-Banking,65,41,100,60,256,256,world,
+online,giropay,GiroPay,65,41,100,60,256,256,world,
+online,google_pay,Google Pay,65,41,100,60,256,256,world,
+online,ideal,iDEAL,65,41,100,60,256,256,world,
+online,interac,Interac Online,65,41,100,60,256,256,world,
+online,kcp_banktransfer,Bank Transfer via KCP,65,41,100,60,256,256,world,
+online,kcp_creditcard,Credit Card via KCP,65,41,100,60,256,256,world,
+online,kcp_payco,PayCo,65,41,100,60,256,256,world,
+online,klarna,Klarna,65,41,100,60,256,256,world,
+online,molpay_points,MOLPoints via MOLPay,65,41,100,60,256,256,world,
+online,multibanco,Multibanco,65,41,100,60,256,256,world,
+online,paypal,PayPal,65,41,100,60,180,60,world,
+online,qiwiwallet,Qiwi Wallet,65,41,100,60,256,256,world,
+online,sepadirectdebit,SEPA Direct Debit,65,41,100,60,256,256,world,
+online,trustly,Trustly,65,41,100,60,256,256,world,
+online,trustpay,TrustPay,65,41,100,60,256,256,world,
+online,unionpay,UnionPay,65,41,100,60,256,256,world,
+online,wechatpay,WeChat Pay,65,41,100,60,256,256,world,

--- a/final/final.go
+++ b/final/final.go
@@ -319,6 +319,7 @@ func commonPaymentMethods(data CleansedDataSet, regions []common.Region) []commo
 	var all []common.PaymentMethod
 	for _, pm := range data.PaymentMethods {
 		theseRegions := []string{}
+		theseCapabilities := []string{}
 
 		hasWorld := false
 		for _, regionId := range pm.Regions {
@@ -335,6 +336,11 @@ func commonPaymentMethods(data CleansedDataSet, regions []common.Region) []commo
 			theseRegions = append(theseRegions, "world")
 		}
 
+		for _, capability := range pm.Capabilities {
+			theseCapabilities = append(theseCapabilities, capability)
+		}
+		sort.Strings(theseCapabilities)
+
 		all = append(all, common.PaymentMethod{
 			Id:   pm.Id,
 			Type: pm.Type,
@@ -345,6 +351,7 @@ func commonPaymentMethods(data CleansedDataSet, regions []common.Region) []commo
 				Large:  toPaymentMethodImage(pm.Id, pm.LargeWidth, pm.LargeHeight, "120"),
 			},
 			Regions: theseRegions,
+			Capabilities: theseCapabilities,
 		})
 	}
 	return all

--- a/reference.go
+++ b/reference.go
@@ -21,7 +21,7 @@ func main() {
 	app.Name = "reference"
 	app.Usage = "Flow Reference Library"
 
-	app.Commands = []cli.Command{
+	app.Commands = []*cli.Command{
 		{
 			Name:  "all",
 			Usage: "Runs all scripts",


### PR DESCRIPTION
Add generic payment method `capabilities`.  Initial intent is to introduce `capabilities` to support `card` payment methods, allowing Flow to classify them as `debit` and/or `credit` cards. 

This information will be used by the Frontend to help determine payment method rule ordering in Checkout UI.