### PR TITLE
[CORE-1664] Change Currency UGX Decimal

### DIFF
--- a/data/cleansed/currencies.json
+++ b/data/cleansed/currencies.json
@@ -667,7 +667,7 @@
   {
     "name": "Uganda Shilling",
     "iso_4217_3": "UGX",
-    "number_decimals": 0
+    "number_decimals": 2
   },
   {
     "name": "Ukraine Hryvnia",

--- a/data/final/currencies.json
+++ b/data/final/currencies.json
@@ -1261,7 +1261,7 @@
   {
     "name": "Uganda Shilling",
     "iso_4217_3": "UGX",
-    "number_decimals": 0,
+    "number_decimals": 2,
     "symbols": {
       "primary": "UGX"
     },

--- a/data/javascript/currency-format.json
+++ b/data/javascript/currency-format.json
@@ -1025,7 +1025,7 @@
     "symbol": "UGX",
     "decimal": ".",
     "group": ",",
-    "precision": 0,
+    "precision": 2,
     "format": "%s%v"
   },
   "en-UM": {
@@ -2355,7 +2355,7 @@
     "symbol": "UGX",
     "decimal": ".",
     "group": ",",
-    "precision": 0,
+    "precision": 2,
     "format": "%s%v"
   },
   "ta-LK": {

--- a/data/javascript/currency-format.v2.json
+++ b/data/javascript/currency-format.v2.json
@@ -1466,7 +1466,7 @@
     },
     "decimal": ".",
     "group": ",",
-    "precision": 0,
+    "precision": 2,
     "format": "%s%v"
   },
   "en-UM": {
@@ -3366,7 +3366,7 @@
     },
     "decimal": ".",
     "group": ",",
-    "precision": 0,
+    "precision": 2,
     "format": "%s%v"
   },
   "ta-LK": {

--- a/data/original/currencies.json
+++ b/data/original/currencies.json
@@ -642,7 +642,7 @@
   {
     "iso_4217_3": "UGX",
     "name": "Uganda Shilling",
-    "number_decimals": 0
+    "number_decimals": 2
   },
   {
     "iso_4217_3": "USD",


### PR DESCRIPTION
The Ugandan Shilling (UGX) was a decimal-based currency but is now effectively a zero-decimal currency. To maintain backwards compatibility, amounts must be passed in with two decimals.

https://stripe.com/docs/currencies#zero-decimal