### PR TITLE
[CORE-2849] Update CLP number deimals to 0

### DIFF
--- a/data/cleansed/currencies.json
+++ b/data/cleansed/currencies.json
@@ -137,7 +137,7 @@
   {
     "name": "Chilean Peso",
     "iso_4217_3": "CLP",
-    "number_decimals": 2
+    "number_decimals": 0
   },
   {
     "name": "Colombian Peso",

--- a/data/final/currencies.json
+++ b/data/final/currencies.json
@@ -256,7 +256,7 @@
   {
     "name": "Chilean Peso",
     "iso_4217_3": "CLP",
-    "number_decimals": 2,
+    "number_decimals": 0,
     "symbols": {
       "primary": "CLP",
       "narrow": "$"

--- a/data/original/currencies.json
+++ b/data/original/currencies.json
@@ -122,7 +122,7 @@
   {
     "iso_4217_3": "CLP",
     "name": "Chilean Peso",
-    "number_decimals": 2
+    "number_decimals": 0
   },
   {
     "iso_4217_3": "CNY",


### PR DESCRIPTION
Jira: https://flowio.atlassian.net/browse/CORE-2849?atlOrigin=eyJpIjoiMTAwNTA1ODhjOGI2NDZlZDgzNjNiNmEwMmYzOTYxNTEiLCJwIjoiaiJ9

According to the countries data source, `CLP` is expected to have `0` decimals:
https://github.com/flowcommerce/json-reference/blob/main/data/source/countries.csv

_Note_: The scripts were used to generate the change, though any additional modification were manually removed for the purposes of isolating this change.