### PR TITLE
ISK Zero Decimal

### DIFF
--- a/data/cleansed/currencies.json
+++ b/data/cleansed/currencies.json
@@ -277,7 +277,7 @@
   {
     "name": "Iceland Krona",
     "iso_4217_3": "ISK",
-    "number_decimals": 2
+    "number_decimals": 0
   },
   {
     "name": "Indian Rupee",

--- a/data/final/currencies.json
+++ b/data/final/currencies.json
@@ -524,7 +524,7 @@
   {
     "name": "Iceland Krona",
     "iso_4217_3": "ISK",
-    "number_decimals": 2,
+    "number_decimals": 0,
     "symbols": {
       "primary": "ISK",
       "narrow": "kr"

--- a/data/javascript/currency-format.json
+++ b/data/javascript/currency-format.json
@@ -1711,7 +1711,7 @@
     "symbol": "ISK",
     "decimal": ",",
     "group": ".",
-    "precision": 2,
+    "precision": 0,
     "format": "%s%v"
   },
   "it": {

--- a/data/javascript/currency-format.v2.json
+++ b/data/javascript/currency-format.v2.json
@@ -2446,7 +2446,7 @@
     },
     "decimal": ",",
     "group": ".",
-    "precision": 2,
+    "precision": 0,
     "format": "%s%v"
   },
   "it": {

--- a/data/original/currencies.json
+++ b/data/original/currencies.json
@@ -457,7 +457,7 @@
   {
     "iso_4217_3": "ISK",
     "name": "Iceland Krona",
-    "number_decimals": 2
+    "number_decimals": 0
   },
   {
     "iso_4217_3": "JMD",


### PR DESCRIPTION
Iceland has officially switched to being a zero decimal currency this year according to ISO, as the minor units was sunset in 2002 and no longer used in common practice by 2007. With this change, Stripe has begun rejecting all charges denominated in minor units. 

> Effective 0:00 UTC on 2023-04-14, ISK becomes a zero-decimal currency. To maintain backwards compatibility, you must pass in amounts with two decimals. For example, to charge 5 ISK, provide an amount value of 500. The amount value must be evenly divisible by 100: 100, 200, 300, and so on. You can’t charge fractions of ISK.
https://stripe.com/docs/currencies#special-cases

This means that we *must* price in whole units for all experiences using ISK if they have any chance of processing through Stripe. Currently, the only client with ISK traffic to Stripe is Ledger as they process credit card payments through their Stripe MoR account. Though Ledger already does pricing on whole units in their experiences / pricebooks and does duties unpaid in Iceland, the shipping fee is calculated directly from Euros at a decimal precision of 2. This means that all orders using DHL express or buying only a Nano S will fail because they do not qualify for free shipping.

Unfortunately, I can't find a good way to address this without changing reference across the board. In payments, we are already anticipating this change to make sure that we translate downstream accurately. We may need to make this same assessment for other downstream partners.
https://github.com/flowvault/payment/pull/2087

In the meantime, we want to start rolling this out to select services (Shopify, Experience, Metric) so that we can address the price calculation issue for Ledger and unblock Iceland for them while we work on the broader reference rollout.