### PR TITLE
LOG-1117: Add new SMB service codes

### DIFF
--- a/data/cleansed/carrier-services.json
+++ b/data/cleansed/carrier-services.json
@@ -90,8 +90,18 @@
     "carrier_id": "dhl-parcel"
   },
   {
+    "id": "dhl-parcel-international-direct-smb",
+    "name": "International Direct SMB",
+    "carrier_id": "dhl-parcel"
+  },
+  {
     "id": "dhl-parcel-international-standard",
     "name": "International Standard",
+    "carrier_id": "dhl-parcel"
+  },
+  {
+    "id": "dhl-parcel-international-standard-smb",
+    "name": "International Standard SMB",
     "carrier_id": "dhl-parcel"
   },
   {

--- a/data/final/carrier-services.json
+++ b/data/final/carrier-services.json
@@ -162,8 +162,26 @@
     }
   },
   {
+    "id": "dhl-parcel-international-direct-smb",
+    "name": "International Direct SMB",
+    "carrier": {
+      "id": "dhl-parcel",
+      "name": "DHL Parcel",
+      "tracking_url": "https://webtrack.dhlglobalmail.com/?trackingnumber="
+    }
+  },
+  {
     "id": "dhl-parcel-international-standard",
     "name": "International Standard",
+    "carrier": {
+      "id": "dhl-parcel",
+      "name": "DHL Parcel",
+      "tracking_url": "https://webtrack.dhlglobalmail.com/?trackingnumber="
+    }
+  },
+  {
+    "id": "dhl-parcel-international-standard-smb",
+    "name": "International Standard SMB",
     "carrier": {
       "id": "dhl-parcel",
       "name": "DHL Parcel",

--- a/data/original/carrier-services.csv
+++ b/data/original/carrier-services.csv
@@ -18,6 +18,8 @@ dhl-express-domestic-1800,Express Domestic 18:00,dhl
 dhl-global-mail-packet-plus,Packet Plus,dhl-global-mail
 dhl-parcel-international-direct,International Direct,dhl-parcel
 dhl-parcel-international-standard,International Standard,dhl-parcel
+dhl-parcel-international-direct-smb,International Direct SMB,dhl-parcel
+dhl-parcel-international-standard-smb,International Standard SMB,dhl-parcel
 fedex-ground,Ground,fedex
 fedex-overnight,Overnight,fedex
 fedex-international-economy,International Economy,fedex

--- a/download/download.go
+++ b/download/download.go
@@ -13,7 +13,7 @@ import (
 
 func DownloadAll() {
 	download("data/source/languages.json", "https://raw.githubusercontent.com/bdswiss/country-language/master/data.json")
-	download("data/source/countries.csv", "https://raw.githubusercontent.com/datasets/country-codes/master/data/country-codes.csv")
+	download("data/source/countries.csv", "https://raw.githubusercontent.com/datasets/country-codes/2ed03b6993e817845c504ce9626d519376c8acaa/data/country-codes.csv")
 	download("data/source/country-continents.csv", "http://dev.maxmind.com/static/csv/codes/country_continent.csv")
 	download("data/source/cldr-currencies.json", "https://raw.githubusercontent.com/unicode-cldr/cldr-numbers-full/master/main/en-US-POSIX/currencies.json")
 }


### PR DESCRIPTION
How we're defining the difference in DHL Parcel service types:

DHL Ecom SMB
- Service codes: dhl-parcel-international-direct-smb, dhl-parcel-international-standard-smb 
- First mile: USPS
- Product codes: OLT/OLY (“ONI”)
- Blended rate we offer to all SMP merchants

DHL Ecom Pickup
- service codes: dhl-parcel-international-direct, dhl-parcel-international-standard
- First mile: DHL Ecom
- Product codes: PLT/PLY/”packet”
- Special rate between merchant and DHL
- TSA Approved (no open and inspect)
- For: Custom Ratecards, Legacy Ratecards
