### PR TITLE
LOG-5052: new carrier service fedex-international-connect-plus

### DIFF
--- a/data/cleansed/carrier-services.json
+++ b/data/cleansed/carrier-services.json
@@ -180,6 +180,11 @@
     "carrier_id": "fedex"
   },
   {
+    "id": "fedex-international-connect-plus",
+    "name": "International Connect Plus",
+    "carrier_id": "fedex"
+  },
+  {
     "id": "fedex-international-economy",
     "name": "International Economy",
     "carrier_id": "fedex"

--- a/data/final/carrier-services.json
+++ b/data/final/carrier-services.json
@@ -324,6 +324,15 @@
     }
   },
   {
+    "id": "fedex-international-connect-plus",
+    "name": "International Connect Plus",
+    "carrier": {
+      "id": "fedex",
+      "name": "FedEx",
+      "tracking_url": "https://www.fedex.com/apps/fedextrack/?tracknumbers="
+    }
+  },
+  {
     "id": "fedex-international-economy",
     "name": "International Economy",
     "carrier": {

--- a/data/original/carrier-services.csv
+++ b/data/original/carrier-services.csv
@@ -25,6 +25,7 @@ fedex-overnight,Overnight,fedex
 fedex-international-economy,International Economy,fedex
 fedex-international-priority,International Priority,fedex
 fedex-international-standard,International Standard,fedex
+fedex-international-connect-plus,International Connect Plus,fedex
 fedex-crossborder-ecommerce,E-commerce,fedex-crossborder
 fedex-crossborder-ecommerce-lite,E-commerce Lite,fedex-crossborder
 fedex-crossborder-fic-express-priority,FIC Express Priority,fedex-crossborder


### PR DESCRIPTION
The service we'll be using for FedEx is `FedEx International Connect Plus (FICP)`

fedex-international-connect-plus

Similar to this [PR](https://github.com/flowcommerce/json-reference/pull/121/files) for dhl-parcel 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added FedEx International Connect Plus as a selectable carrier service.
  * Service appears alongside existing FedEx options (e.g., between Ground and International Economy).
  * Tracking supported via FedEx’s standard tracking link.
  * No changes to existing services; all current options remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->