### PR TITLE
COR-3430 - replace Bulgaria currency to EUR

### DIFF
--- a/data/cleansed/countries.json
+++ b/data/cleansed/countries.json
@@ -242,7 +242,7 @@
     "continent": "EU",
     "iso_3166_2": "BG",
     "iso_3166_3": "BGR",
-    "currency": "BGN"
+    "currency": "EUR"
   },
   {
     "name": "Burkina Faso",

--- a/data/final/countries.json
+++ b/data/final/countries.json
@@ -432,7 +432,7 @@
     "iso_3166_2": "BG",
     "iso_3166_3": "BGR",
     "measurement_system": "metric",
-    "default_currency": "BGN",
+    "default_currency": "EUR",
     "default_language": "bg",
     "languages": [
       "bg"

--- a/data/final/regions.json
+++ b/data/final/regions.json
@@ -881,7 +881,7 @@
       "BGR"
     ],
     "currencies": [
-      "BGN"
+      "EUR"
     ],
     "languages": [
       "bg"
@@ -1863,6 +1863,7 @@
     "countries": [
       "AUT",
       "BEL",
+      "BGR",
       "CYP",
       "EST",
       "FIN",
@@ -1887,6 +1888,7 @@
     ],
     "languages": [
       "cs",
+      "bg",
       "de",
       "el",
       "en",


### PR DESCRIPTION
[COR-3430] - replace Bulgaria currency to EUR

[COR-3430]: https://flowio.atlassian.net/browse/COR-3430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Bulgaria's currency from BGN to EUR across datasets.
  * Added Bulgaria to Europe and Eurozone country lists and included Bulgarian (bg) in languages.
  * Minor formatting cleanup (ensured trailing newline/EOF consistency).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->