### PR TITLE
COR-3798 - Adding MKD currency

### DIFF
--- a/data/cleansed/currencies.json
+++ b/data/cleansed/currencies.json
@@ -365,6 +365,11 @@
     "number_decimals": 2
   },
   {
+    "name": "Macedonian Denar",
+    "iso_4217_3": "MKD",
+    "number_decimals": 2
+  },
+  {
     "name": "Malagasy Ariary",
     "iso_4217_3": "MGA",
     "number_decimals": 2

--- a/data/final/countries.json
+++ b/data/final/countries.json
@@ -2122,7 +2122,7 @@
     "iso_3166_2": "MK",
     "iso_3166_3": "MKD",
     "measurement_system": "metric",
-    "default_currency": "EUR",
+    "default_currency": "MKD",
     "default_language": "mk",
     "languages": [
       "mk"

--- a/data/final/currencies.json
+++ b/data/final/currencies.json
@@ -693,6 +693,15 @@
     "default_locale": "zh-MO"
   },
   {
+    "name": "Macedonian Denar",
+    "iso_4217_3": "MKD",
+    "number_decimals": 2,
+    "symbols": {
+      "primary": "MKD"
+    },
+    "default_locale": "sk-MK"
+  },
+  {
     "name": "Malagasy Ariary",
     "iso_4217_3": "MGA",
     "number_decimals": 2,

--- a/data/final/currencies.json
+++ b/data/final/currencies.json
@@ -699,7 +699,7 @@
     "symbols": {
       "primary": "MKD"
     },
-    "default_locale": "sk-MK"
+    "default_locale": "mk-MK"
   },
   {
     "name": "Malagasy Ariary",

--- a/data/final/regions.json
+++ b/data/final/regions.json
@@ -3569,7 +3569,7 @@
       "MKD"
     ],
     "currencies": [
-      "EUR"
+      "EUR", "MKD"
     ],
     "languages": [
       "mk"

--- a/data/final/regions.json
+++ b/data/final/regions.json
@@ -3569,7 +3569,7 @@
       "MKD"
     ],
     "currencies": [
-      "EUR", "MKD"
+      "MKD"
     ],
     "languages": [
       "mk"


### PR DESCRIPTION
NOTE: MKD currency was already present in some other json file references like in `regions` file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added support for the Macedonian Denar (MKD): localized formatting, primary currency symbol "MKD", default locale "mk-MK", and two decimal places for amounts.
  * Updated North Macedonia to use MKD as the region currency (replacing EUR) and set the country's default currency to MKD.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->