### PR TITLE
COR-3990: Add BTN currency

### DIFF
--- a/data/final/currencies.json
+++ b/data/final/currencies.json
@@ -131,6 +131,15 @@
     }
   },
   {
+    "name": "Bhutanese Ngultrum",
+    "iso_4217_3": "BTN",
+    "number_decimals": 2,
+    "symbols": {
+      "primary": "BTN"
+    },
+    "default_locale": "bn-IN"
+  },
+  {
     "name": "Bolivia Boliviano",
     "iso_4217_3": "BOB",
     "number_decimals": 2,

--- a/data/final/regions.json
+++ b/data/final/regions.json
@@ -713,7 +713,7 @@
       "BTN"
     ],
     "currencies": [
-      "INR"
+      "INR", "BTN"
     ],
     "languages": [
       "dz"

--- a/data/final/regions.json
+++ b/data/final/regions.json
@@ -713,7 +713,7 @@
       "BTN"
     ],
     "currencies": [
-      "INR", "BTN"
+      "BTN", "INR"
     ],
     "languages": [
       "dz"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Bhutanese Ngultrum (BTN) as a recognized currency, including its display symbol and default locale handling.
  * Updated Bhutan region configuration to include both Bhutanese Ngultrum and Indian Rupee, enabling proper currency selection and formatting for Bhutan-based contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->